### PR TITLE
feat: add sliding session settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,8 +161,9 @@ This project currently uses MySQL persistence.
 Logical stores:
 
 - generic async task records + task events
-- 5-minute conversation history windows
+- sliding-window conversation history
 - Claude plugin private state
+- runtime settings such as `session.window_seconds`
 
 ### Meaning of Each Store
 
@@ -175,7 +176,13 @@ Generic task store:
 Conversation store:
 
 - persistent conversation windows used by `intent` and `reply`
-- conversation windows are still logically 5-minute windows
+- conversation windows are keyed by session and expire by `last_active + session.window_seconds`
+
+Runtime settings store:
+
+- small key/value runtime settings persisted in MySQL
+- currently used for `session.window_seconds`
+- service startup is expected to ensure default settings rows exist
 
 Claude-private store:
 
@@ -202,8 +209,9 @@ Conversation history is persisted and reused.
 
 Current rule:
 
-- a conversation window lasts 5 minutes from the start of the window
-- it is not a sliding “last activity + 5m” window
+- conversation reuse is based on a sliding window
+- a session stays active while `last_active + session.window_seconds` has not expired
+- current default is `300` seconds, and it can be adjusted through the dashboard settings API
 
 What gets written:
 
@@ -408,6 +416,8 @@ Important routes:
 
 - `GET /api/healthz`
 - `GET /api/state`
+- `GET /api/settings`
+- `POST /api/settings/session`
 - `POST /api/reset`
 
 The frontend is separate and should stay that way.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ flowchart TD
 - 管理轻量异步任务，并在后续对话中补报进度
 - 提供独立的 React + Vite dashboard
 - 使用 MySQL 保存任务、会话和插件私有状态
+- 会话上下文默认使用滑动窗口，并支持在 Dashboard 中调整窗口秒数
 
 当前内置工具：
 
@@ -143,24 +144,24 @@ reply:
 
 `SOUL.md` 会在启动时一并读取，用于定义主回复的人设。`config.yaml` 已被忽略，不要提交真实密钥。
 
-3. 先准备数据库：
-
-```sql
-CREATE DATABASE open_xiaoai_agent CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-```
-
-4. 设置运行时数据库 DSN：
+3. 设置运行时数据库 DSN：
 
 ```sh
 export OPEN_XIAOAI_AGENT_DSN='user:pass@tcp(127.0.0.1:3306)/open_xiaoai_agent'
 ```
 
-5. 安装依赖并启动：
+4. 安装依赖并启动：
 
 ```sh
 npm install
 npm run dev
 ```
+
+服务启动后会自动：
+
+- 创建目标数据库（如果还不存在）
+- 创建运行期所需表结构
+- 写入默认会话窗口设置 `session.window_seconds = 300`
 
 默认端口：
 
@@ -230,6 +231,8 @@ Go 后端只提供 API，前端位于 `web/`。
 
 - `GET /api/healthz`
 - `GET /api/state`
+- `GET /api/settings`
+- `POST /api/settings/session`
 - `POST /api/reset`
 
 ## 验证

--- a/internal/assistant/history.go
+++ b/internal/assistant/history.go
@@ -17,6 +17,10 @@ type sessionKeyer interface {
 	HistoryKey() string
 }
 
+type sessionWindowProvider interface {
+	SessionWindow() time.Duration
+}
+
 type conversationHistory struct {
 	id         string
 	startedAt  time.Time
@@ -32,26 +36,22 @@ type ConversationSnapshot struct {
 }
 
 type historyStore struct {
-	mu      sync.Mutex
-	window  time.Duration
-	db      *sql.DB
-	entries map[string]*conversationHistory
+	mu       sync.Mutex
+	settings sessionWindowProvider
+	db       *sql.DB
+	entries  map[string]*conversationHistory
 }
 
-func newHistoryStore(window time.Duration, dsn string) (*historyStore, error) {
-	if window <= 0 {
-		window = 5 * time.Minute
-	}
-
+func newHistoryStore(settings sessionWindowProvider, dsn string) (*historyStore, error) {
 	db, err := storage.OpenRuntimeDB(dsn)
 	if err != nil {
 		return nil, err
 	}
 
 	store := &historyStore{
-		window:  window,
-		db:      db,
-		entries: make(map[string]*conversationHistory),
+		settings: settings,
+		db:       db,
+		entries:  make(map[string]*conversationHistory),
 	}
 	if err := store.load(); err != nil {
 		return nil, err
@@ -64,7 +64,7 @@ func (s *historyStore) Snapshot(session any, now time.Time) []llm.Message {
 	defer s.mu.Unlock()
 
 	changed := s.pruneExpiredLocked(now)
-	entry, created := s.ensureEntryLocked(session, now)
+	entry, created := s.ensureEntryLocked(session, now, false)
 	if changed || created {
 		s.saveLocked()
 	}
@@ -76,7 +76,7 @@ func (s *historyStore) AppendTurn(session any, now time.Time, user string, assis
 	defer s.mu.Unlock()
 
 	changed := s.pruneExpiredLocked(now)
-	entry, created := s.ensureEntryLocked(session, now)
+	entry, created := s.ensureEntryLocked(session, now, true)
 	if user != "" {
 		entry.messages = append(entry.messages, llm.Message{
 			Role:    "user",
@@ -169,13 +169,17 @@ func (s *historyStore) load() error {
 			return fmt.Errorf("scan conversation: %w", err)
 		}
 		started := storage.TimeFromUnixMillis(startedAt)
-		if strings.TrimSpace(id) == "" || now.Sub(started) > s.window {
+		last := storage.TimeFromUnixMillis(lastActive)
+		if last.IsZero() {
+			last = started
+		}
+		if strings.TrimSpace(id) == "" || now.Sub(last) > s.sessionWindowLocked() {
 			continue
 		}
 		s.entries[id] = &conversationHistory{
 			id:         id,
 			startedAt:  started,
-			lastActive: storage.TimeFromUnixMillis(lastActive),
+			lastActive: last,
 		}
 	}
 	if err := rows.Err(); err != nil {
@@ -214,10 +218,10 @@ func (s *historyStore) load() error {
 	return nil
 }
 
-func (s *historyStore) ensureEntryLocked(session any, now time.Time) (*conversationHistory, bool) {
+func (s *historyStore) ensureEntryLocked(session any, now time.Time, touch bool) (*conversationHistory, bool) {
 	key := conversationKey(session)
 	entry, ok := s.entries[key]
-	if !ok || now.Sub(entry.startedAt) > s.window {
+	if !ok || now.Sub(entry.lastActive) > s.sessionWindowLocked() {
 		entry = &conversationHistory{
 			id:         key,
 			startedAt:  now,
@@ -227,14 +231,17 @@ func (s *historyStore) ensureEntryLocked(session any, now time.Time) (*conversat
 		return entry, true
 	}
 
-	entry.lastActive = now
+	if touch {
+		entry.lastActive = now
+	}
 	return entry, false
 }
 
 func (s *historyStore) pruneExpiredLocked(now time.Time) bool {
 	changed := false
+	window := s.sessionWindowLocked()
 	for key, entry := range s.entries {
-		if now.Sub(entry.startedAt) <= s.window {
+		if now.Sub(entry.lastActive) <= window {
 			continue
 		}
 		delete(s.entries, key)
@@ -322,6 +329,17 @@ func (s *historyStore) saveLocked() {
 	if err := tx.Commit(); err != nil {
 		log.Printf("conversation save failed: commit: %v", err)
 	}
+}
+
+func (s *historyStore) sessionWindowLocked() time.Duration {
+	if s.settings == nil {
+		return 5 * time.Minute
+	}
+	window := s.settings.SessionWindow()
+	if window <= 0 {
+		return 5 * time.Minute
+	}
+	return window
 }
 
 func conversationKey(session any) string {

--- a/internal/assistant/history_test.go
+++ b/internal/assistant/history_test.go
@@ -5,6 +5,14 @@ import (
 	"time"
 )
 
+type staticSessionWindow struct {
+	window time.Duration
+}
+
+func (s staticSessionWindow) SessionWindow() time.Duration {
+	return s.window
+}
+
 type historyTestSession struct {
 	id string
 }
@@ -16,7 +24,7 @@ func (s historyTestSession) HistoryKey() string {
 func TestHistoryStoreResetsAfterWindow(t *testing.T) {
 	t.Parallel()
 
-	store, err := newHistoryStore(5*time.Minute, "")
+	store, err := newHistoryStore(staticSessionWindow{window: 5 * time.Minute}, "")
 	if err != nil {
 		t.Fatalf("newHistoryStore() error = %v", err)
 	}
@@ -35,34 +43,26 @@ func TestHistoryStoreResetsAfterWindow(t *testing.T) {
 	}
 }
 
-func TestHistoryStoreSnapshotAllKeepsActiveAndSorts(t *testing.T) {
+func TestHistoryStoreSlidingWindowUsesLastActive(t *testing.T) {
 	t.Parallel()
 
-	store, err := newHistoryStore(5*time.Minute, "")
+	store, err := newHistoryStore(staticSessionWindow{window: 5 * time.Minute}, "")
 	if err != nil {
 		t.Fatalf("newHistoryStore() error = %v", err)
 	}
-	sessionA := historyTestSession{id: "session-a"}
-	sessionB := historyTestSession{id: "session-b"}
+	session := historyTestSession{id: "session-a"}
 	start := time.Date(2026, 4, 24, 16, 0, 0, 0, time.Local)
 
-	store.AppendTurn(sessionA, start, "A1", "A2")
-	store.AppendTurn(sessionB, start.Add(2*time.Minute), "B1", "B2")
+	store.AppendTurn(session, start, "A1", "A2")
+	store.AppendTurn(session, start.Add(4*time.Minute), "A3", "A4")
 
-	snapshots := store.SnapshotAll(start.Add(3 * time.Minute))
-	if len(snapshots) != 2 {
-		t.Fatalf("len(snapshots) = %d, want 2", len(snapshots))
+	history := store.Snapshot(session, start.Add(8*time.Minute))
+	if len(history) != 4 {
+		t.Fatalf("len(history) = %d, want 4", len(history))
 	}
-	if snapshots[0].Messages[0].Content != "B1" {
-		t.Fatalf("snapshots[0].Messages[0].Content = %q, want B1", snapshots[0].Messages[0].Content)
-	}
-
-	snapshots = store.SnapshotAll(start.Add(7 * time.Minute))
-	if len(snapshots) != 1 {
-		t.Fatalf("len(snapshots) = %d, want 1 after expiration", len(snapshots))
-	}
-	if snapshots[0].Messages[0].Content != "B1" {
-		t.Fatalf("snapshots[0].Messages[0].Content = %q, want B1", snapshots[0].Messages[0].Content)
+	history = store.Snapshot(session, start.Add(10*time.Minute))
+	if len(history) != 0 {
+		t.Fatalf("len(history) = %d, want 0 after sliding expiration", len(history))
 	}
 }
 
@@ -73,13 +73,13 @@ func TestHistoryStorePersistsConversation(t *testing.T) {
 	start := time.Now()
 	session := historyTestSession{id: "session-persist"}
 
-	store, err := newHistoryStore(5*time.Minute, path)
+	store, err := newHistoryStore(staticSessionWindow{window: 5 * time.Minute}, path)
 	if err != nil {
 		t.Fatalf("newHistoryStore() error = %v", err)
 	}
 	store.AppendTurn(session, start, "你好", "你好呀")
 
-	reloaded, err := newHistoryStore(5*time.Minute, path)
+	reloaded, err := newHistoryStore(staticSessionWindow{window: 5 * time.Minute}, path)
 	if err != nil {
 		t.Fatalf("reload newHistoryStore() error = %v", err)
 	}
@@ -100,7 +100,7 @@ func TestHistoryStoreResetClearsPersistence(t *testing.T) {
 	start := time.Now()
 	session := historyTestSession{id: "session-reset"}
 
-	store, err := newHistoryStore(5*time.Minute, path)
+	store, err := newHistoryStore(staticSessionWindow{window: 5 * time.Minute}, path)
 	if err != nil {
 		t.Fatalf("newHistoryStore() error = %v", err)
 	}
@@ -114,7 +114,7 @@ func TestHistoryStoreResetClearsPersistence(t *testing.T) {
 		t.Fatalf("len(snapshots) = %d, want 0", len(snapshots))
 	}
 
-	reloaded, err := newHistoryStore(5*time.Minute, path)
+	reloaded, err := newHistoryStore(staticSessionWindow{window: 5 * time.Minute}, path)
 	if err != nil {
 		t.Fatalf("reload newHistoryStore() error = %v", err)
 	}

--- a/internal/assistant/service.go
+++ b/internal/assistant/service.go
@@ -43,7 +43,6 @@ type TaskManager interface {
 type Config struct {
 	AbortAfterASR         bool
 	PostAbortDelay        time.Duration
-	SessionWindow         time.Duration
 	UseParallelIntentChat bool
 	StateDSN              string
 }
@@ -58,14 +57,11 @@ type Service struct {
 	history *historyStore
 }
 
-func New(config Config, intent IntentDecider, reply ReplyStreamer, tools ToolRunner, taskManager TaskManager, spk *speaker.Speaker) (*Service, error) {
-	if config.SessionWindow <= 0 {
-		config.SessionWindow = 5 * time.Minute
-	}
+func New(config Config, sessionSettings sessionWindowProvider, intent IntentDecider, reply ReplyStreamer, tools ToolRunner, taskManager TaskManager, spk *speaker.Speaker) (*Service, error) {
 	if config.PostAbortDelay < 0 {
 		config.PostAbortDelay = 0
 	}
-	history, err := newHistoryStore(config.SessionWindow, config.StateDSN)
+	history, err := newHistoryStore(sessionSettings, config.StateDSN)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/assistant/service_test.go
+++ b/internal/assistant/service_test.go
@@ -148,7 +148,7 @@ func (m *fakeTaskManager) MarkReported(ids []string) error {
 func newTestService(t *testing.T, config Config, intent IntentDecider, reply ReplyStreamer, tools ToolRunner, taskManager TaskManager, spk *speaker.Speaker) *Service {
 	t.Helper()
 
-	service, err := New(config, intent, reply, tools, taskManager, spk)
+	service, err := New(config, staticSessionWindow{window: 5 * time.Minute}, intent, reply, tools, taskManager, spk)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -501,7 +501,7 @@ func TestHandleASRIncludesSessionHistory(t *testing.T) {
 	var seenHistory []llm.Message
 
 	service := newTestService(t,
-		Config{AbortAfterASR: true, PostAbortDelay: 0, SessionWindow: 5 * time.Minute},
+		Config{AbortAfterASR: true, PostAbortDelay: 0},
 		fakeIntent{
 			onDecide: func(history []llm.Message, text string) llm.IntentDecision {
 				seenHistory = append([]llm.Message(nil), history...)
@@ -549,7 +549,6 @@ func TestHandleASRUsesSpeculativeReplyWhenEnabled(t *testing.T) {
 		Config{
 			AbortAfterASR:         true,
 			PostAbortDelay:        0,
-			SessionWindow:         5 * time.Minute,
 			UseParallelIntentChat: true,
 		},
 		fakeIntent{

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -2,11 +2,13 @@ package dashboard
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/assistant"
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/plugins/complextask"
+	"github.com/luoliwoshang/open-xiaoai-agent/internal/settings"
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/tasks"
 )
 
@@ -18,19 +20,34 @@ type Server struct {
 		SnapshotConversations() []assistant.ConversationSnapshot
 		ResetConversationData() error
 	}
+	settings interface {
+		Snapshot() settings.Snapshot
+		UpdateSessionWindowSeconds(seconds int) (settings.Snapshot, error)
+	}
 }
 
 func New(addr string, tasks *tasks.Manager, claude *complextask.Service, conversations interface {
 	SnapshotConversations() []assistant.ConversationSnapshot
 	ResetConversationData() error
+}, runtimeSettings interface {
+	Snapshot() settings.Snapshot
+	UpdateSessionWindowSeconds(seconds int) (settings.Snapshot, error)
 }) *Server {
-	return &Server{addr: addr, tasks: tasks, claude: claude, conversations: conversations}
+	return &Server{
+		addr:          addr,
+		tasks:         tasks,
+		claude:        claude,
+		conversations: conversations,
+		settings:      runtimeSettings,
+	}
 }
 
 func (s *Server) ListenAndServe() error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/healthz", s.handleHealth)
 	mux.HandleFunc("/api/state", s.handleState)
+	mux.HandleFunc("/api/settings", s.handleSettings)
+	mux.HandleFunc("/api/settings/session", s.handleSessionSettings)
 	mux.HandleFunc("/api/reset", s.handleReset)
 
 	log.Printf("dashboard api listening on %s", s.addr)
@@ -47,16 +64,69 @@ func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
 	if s.conversations != nil {
 		conversations = s.conversations.SnapshotConversations()
 	}
+	var runtimeSettings settings.Snapshot
+	if s.settings != nil {
+		runtimeSettings = s.settings.Snapshot()
+	}
 	writeJSON(w, map[string]any{
 		"tasks":          tasksList,
 		"events":         events,
 		"claude_records": claudeRecords,
 		"conversations":  conversations,
+		"settings":       runtimeSettings,
 	})
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, map[string]any{"ok": true})
+}
+
+func (s *Server) handleSettings(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if s.settings == nil {
+		http.Error(w, "settings are not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	writeJSON(w, map[string]any{
+		"session": s.settings.Snapshot(),
+	})
+}
+
+func (s *Server) handleSessionSettings(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.settings == nil {
+		http.Error(w, "settings are not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	var payload struct {
+		WindowSeconds int `json:"window_seconds"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, fmt.Sprintf("decode session settings: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	snapshot, err := s.settings.UpdateSessionWindowSeconds(payload.WindowSeconds)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	writeJSON(w, map[string]any{
+		"ok":      true,
+		"session": snapshot,
+	})
 }
 
 func (s *Server) handleReset(w http.ResponseWriter, r *http.Request) {

--- a/internal/dashboard/server_test.go
+++ b/internal/dashboard/server_test.go
@@ -2,14 +2,17 @@ package dashboard
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/assistant"
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/plugin"
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/plugins/complextask"
+	"github.com/luoliwoshang/open-xiaoai-agent/internal/settings"
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/tasks"
 )
 
@@ -26,6 +29,22 @@ func (f *fakeConversations) ResetConversationData() error {
 	return nil
 }
 
+type fakeSettings struct {
+	snapshot settings.Snapshot
+}
+
+func (f *fakeSettings) Snapshot() settings.Snapshot {
+	return f.snapshot
+}
+
+func (f *fakeSettings) UpdateSessionWindowSeconds(seconds int) (settings.Snapshot, error) {
+	if err := settings.ValidateSessionWindowSeconds(seconds); err != nil {
+		return settings.Snapshot{}, err
+	}
+	f.snapshot = settings.Snapshot{SessionWindowSeconds: seconds}
+	return f.snapshot, nil
+}
+
 func TestHandleResetClearsRuntimeData(t *testing.T) {
 	t.Parallel()
 
@@ -40,6 +59,7 @@ func TestHandleResetClearsRuntimeData(t *testing.T) {
 	}
 	claude := complextask.NewService(store, nil)
 	conversations := &fakeConversations{}
+	runtimeSettings := &fakeSettings{snapshot: settings.Snapshot{SessionWindowSeconds: 300}}
 
 	_, err = manager.Submit(plugin.AsyncTask{
 		Plugin: "complex_task",
@@ -61,7 +81,7 @@ func TestHandleResetClearsRuntimeData(t *testing.T) {
 		t.Fatalf("Start() error = %v", err)
 	}
 
-	server := New(":0", manager, claude, conversations)
+	server := New(":0", manager, claude, conversations, runtimeSettings)
 	req := httptest.NewRequest(http.MethodPost, "/api/reset", nil)
 	recorder := httptest.NewRecorder()
 
@@ -92,7 +112,7 @@ func TestHandleResetClearsRuntimeData(t *testing.T) {
 func TestHandleResetRejectsNonPost(t *testing.T) {
 	t.Parallel()
 
-	server := New(":0", nil, nil, &fakeConversations{})
+	server := New(":0", nil, nil, &fakeConversations{}, &fakeSettings{snapshot: settings.Snapshot{SessionWindowSeconds: 300}})
 	req := httptest.NewRequest(http.MethodGet, "/api/reset", nil)
 	recorder := httptest.NewRecorder()
 
@@ -100,5 +120,61 @@ func TestHandleResetRejectsNonPost(t *testing.T) {
 
 	if recorder.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+func TestHandleSettingsReturnsSnapshot(t *testing.T) {
+	t.Parallel()
+
+	server := New(":0", nil, nil, nil, &fakeSettings{snapshot: settings.Snapshot{SessionWindowSeconds: 300}})
+	req := httptest.NewRequest(http.MethodGet, "/api/settings", nil)
+	recorder := httptest.NewRecorder()
+
+	server.handleSettings(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+
+	var payload struct {
+		Session settings.Snapshot `json:"session"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if payload.Session.SessionWindowSeconds != 300 {
+		t.Fatalf("SessionWindowSeconds = %d, want 300", payload.Session.SessionWindowSeconds)
+	}
+}
+
+func TestHandleSessionSettingsUpdatesWindowSeconds(t *testing.T) {
+	t.Parallel()
+
+	runtimeSettings := &fakeSettings{snapshot: settings.Snapshot{SessionWindowSeconds: 300}}
+	server := New(":0", nil, nil, nil, runtimeSettings)
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/session", strings.NewReader(`{"window_seconds":420}`))
+	recorder := httptest.NewRecorder()
+
+	server.handleSessionSettings(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if runtimeSettings.snapshot.SessionWindowSeconds != 420 {
+		t.Fatalf("SessionWindowSeconds = %d, want 420", runtimeSettings.snapshot.SessionWindowSeconds)
+	}
+}
+
+func TestHandleSessionSettingsRejectsInvalidValue(t *testing.T) {
+	t.Parallel()
+
+	server := New(":0", nil, nil, nil, &fakeSettings{snapshot: settings.Snapshot{SessionWindowSeconds: 300}})
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/session", strings.NewReader(`{"window_seconds":1}`))
+	recorder := httptest.NewRecorder()
+
+	server.handleSessionSettings(recorder, req)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
 	}
 }

--- a/internal/settings/store.go
+++ b/internal/settings/store.go
@@ -1,0 +1,136 @@
+package settings
+
+import (
+	"database/sql"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/luoliwoshang/open-xiaoai-agent/internal/storage"
+)
+
+const (
+	MinSessionWindowSeconds = 30
+	MaxSessionWindowSeconds = 3600
+)
+
+type Snapshot struct {
+	SessionWindowSeconds int `json:"session_window_seconds"`
+}
+
+type Store struct {
+	mu       sync.RWMutex
+	db       *sql.DB
+	snapshot Snapshot
+}
+
+func NewStore(dsn string) (*Store, error) {
+	db, err := storage.OpenRuntimeDB(dsn)
+	if err != nil {
+		return nil, err
+	}
+
+	store := &Store{db: db}
+	snapshot, err := store.load()
+	if err != nil {
+		return nil, err
+	}
+	store.snapshot = snapshot
+	return store, nil
+}
+
+func (s *Store) Snapshot() Snapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.snapshot
+}
+
+func (s *Store) SessionWindow() time.Duration {
+	seconds := s.Snapshot().SessionWindowSeconds
+	if seconds <= 0 {
+		seconds = storage.DefaultSessionWindowSeconds
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+func (s *Store) UpdateSessionWindowSeconds(seconds int) (Snapshot, error) {
+	if err := ValidateSessionWindowSeconds(seconds); err != nil {
+		return Snapshot{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	snapshot := Snapshot{SessionWindowSeconds: seconds}
+	if s.db == nil {
+		s.snapshot = snapshot
+		return snapshot, nil
+	}
+
+	if _, err := s.db.Exec(
+		`UPDATE settings SET value = ?, updated_at = ? WHERE setting_key = ?`,
+		strconv.Itoa(seconds),
+		time.Now().UnixMilli(),
+		storage.SessionWindowSecondsSettingKey,
+	); err != nil {
+		return Snapshot{}, fmt.Errorf("update session window seconds: %w", err)
+	}
+
+	s.snapshot = snapshot
+	return snapshot, nil
+}
+
+func ValidateSessionWindowSeconds(seconds int) error {
+	switch {
+	case seconds < MinSessionWindowSeconds:
+		return fmt.Errorf("session window seconds must be at least %d", MinSessionWindowSeconds)
+	case seconds > MaxSessionWindowSeconds:
+		return fmt.Errorf("session window seconds must be at most %d", MaxSessionWindowSeconds)
+	default:
+		return nil
+	}
+}
+
+func (s *Store) load() (Snapshot, error) {
+	if s.db == nil {
+		return Snapshot{SessionWindowSeconds: storage.DefaultSessionWindowSeconds}, nil
+	}
+
+	var raw string
+	err := s.db.QueryRow(
+		`SELECT value FROM settings WHERE setting_key = ?`,
+		storage.SessionWindowSecondsSettingKey,
+	).Scan(&raw)
+	if err == sql.ErrNoRows {
+		return s.repairDefault()
+	}
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("load session window seconds: %w", err)
+	}
+
+	seconds, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("parse session window seconds %q: %w", raw, err)
+	}
+	if err := ValidateSessionWindowSeconds(seconds); err != nil {
+		return Snapshot{}, err
+	}
+
+	return Snapshot{SessionWindowSeconds: seconds}, nil
+}
+
+func (s *Store) repairDefault() (Snapshot, error) {
+	snapshot := Snapshot{SessionWindowSeconds: storage.DefaultSessionWindowSeconds}
+	if _, err := s.db.Exec(
+		`INSERT INTO settings (setting_key, value, updated_at) VALUES (?, ?, ?)`,
+		storage.SessionWindowSecondsSettingKey,
+		strconv.Itoa(snapshot.SessionWindowSeconds),
+		time.Now().UnixMilli(),
+	); err != nil {
+		return Snapshot{}, fmt.Errorf("insert default session window seconds: %w", err)
+	}
+	return snapshot, nil
+}

--- a/internal/settings/store_test.go
+++ b/internal/settings/store_test.go
@@ -1,0 +1,64 @@
+package settings
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewStoreLoadsDefaultSessionWindowSeconds(t *testing.T) {
+	t.Parallel()
+
+	store, err := NewStore("sqlite://" + t.TempDir() + "/agent.db")
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	snapshot := store.Snapshot()
+	if snapshot.SessionWindowSeconds != 300 {
+		t.Fatalf("SessionWindowSeconds = %d, want 300", snapshot.SessionWindowSeconds)
+	}
+	if store.SessionWindow() != 300*time.Second {
+		t.Fatalf("SessionWindow() = %s, want 300s", store.SessionWindow())
+	}
+}
+
+func TestStoreUpdateSessionWindowSeconds(t *testing.T) {
+	t.Parallel()
+
+	dsn := "sqlite://" + t.TempDir() + "/agent.db"
+	store, err := NewStore(dsn)
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	snapshot, err := store.UpdateSessionWindowSeconds(420)
+	if err != nil {
+		t.Fatalf("UpdateSessionWindowSeconds() error = %v", err)
+	}
+	if snapshot.SessionWindowSeconds != 420 {
+		t.Fatalf("SessionWindowSeconds = %d, want 420", snapshot.SessionWindowSeconds)
+	}
+
+	reloaded, err := NewStore(dsn)
+	if err != nil {
+		t.Fatalf("reload NewStore() error = %v", err)
+	}
+	if reloaded.Snapshot().SessionWindowSeconds != 420 {
+		t.Fatalf("reloaded SessionWindowSeconds = %d, want 420", reloaded.Snapshot().SessionWindowSeconds)
+	}
+}
+
+func TestStoreRejectsInvalidSessionWindowSeconds(t *testing.T) {
+	t.Parallel()
+
+	store, err := NewStore("sqlite://" + t.TempDir() + "/agent.db")
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	for _, value := range []int{0, 29, 3601} {
+		if _, err := store.UpdateSessionWindowSeconds(value); err == nil {
+			t.Fatalf("UpdateSessionWindowSeconds(%d) error = nil, want error", value)
+		}
+	}
+}

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -5,12 +5,18 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
 	mysqlcfg "github.com/go-sql-driver/mysql"
 	_ "github.com/mattn/go-sqlite3"
+)
+
+const (
+	SessionWindowSecondsSettingKey = "session.window_seconds"
+	DefaultSessionWindowSeconds    = 300
 )
 
 func OpenRuntimeDB(dsn string) (*sql.DB, error) {
@@ -62,6 +68,9 @@ func openMySQL(rawDSN string) (*sql.DB, error) {
 	}
 	if _, ok := cfg.Params["charset"]; !ok {
 		cfg.Params["charset"] = "utf8mb4"
+	}
+	if err := ensureMySQLDatabase(cfg); err != nil {
+		return nil, err
 	}
 
 	db, err := sql.Open("mysql", cfg.FormatDSN())
@@ -161,6 +170,11 @@ func ensureSchema(db *sql.DB) error {
 			created_at BIGINT NOT NULL,
 			updated_at BIGINT NOT NULL
 		)`,
+		`CREATE TABLE IF NOT EXISTS settings (
+			setting_key VARCHAR(255) PRIMARY KEY,
+			value VARCHAR(255) NOT NULL,
+			updated_at BIGINT NOT NULL
+		)`,
 	}
 
 	for _, statement := range statements {
@@ -168,5 +182,68 @@ func ensureSchema(db *sql.DB) error {
 			return fmt.Errorf("ensure runtime schema: %w", err)
 		}
 	}
+	if err := ensureDefaultSettings(db); err != nil {
+		return err
+	}
 	return nil
+}
+
+func ensureMySQLDatabase(cfg *mysqlcfg.Config) error {
+	adminCfg := *cfg
+	dbName := strings.TrimSpace(adminCfg.DBName)
+	adminCfg.DBName = ""
+
+	adminDB, err := sql.Open("mysql", adminCfg.FormatDSN())
+	if err != nil {
+		return fmt.Errorf("open mysql admin connection: %w", err)
+	}
+	defer adminDB.Close()
+
+	adminDB.SetConnMaxLifetime(5 * time.Minute)
+	adminDB.SetMaxOpenConns(2)
+	adminDB.SetMaxIdleConns(2)
+
+	if err := adminDB.Ping(); err != nil {
+		return fmt.Errorf("ping mysql admin connection: %w", err)
+	}
+
+	query := fmt.Sprintf(
+		"CREATE DATABASE IF NOT EXISTS %s CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci",
+		quoteMySQLIdentifier(dbName),
+	)
+	if _, err := adminDB.Exec(query); err != nil {
+		return fmt.Errorf("ensure mysql database %q: %w", dbName, err)
+	}
+	return nil
+}
+
+func ensureDefaultSettings(db *sql.DB) error {
+	defaults := map[string]string{
+		SessionWindowSecondsSettingKey: strconv.Itoa(DefaultSessionWindowSeconds),
+	}
+
+	for key, value := range defaults {
+		var exists int
+		err := db.QueryRow(`SELECT 1 FROM settings WHERE setting_key = ? LIMIT 1`, key).Scan(&exists)
+		switch {
+		case err == nil:
+			continue
+		case err != sql.ErrNoRows:
+			return fmt.Errorf("query setting %q: %w", key, err)
+		}
+
+		if _, err := db.Exec(
+			`INSERT INTO settings (setting_key, value, updated_at) VALUES (?, ?, ?)`,
+			key,
+			value,
+			time.Now().UnixMilli(),
+		); err != nil {
+			return fmt.Errorf("insert default setting %q: %w", key, err)
+		}
+	}
+	return nil
+}
+
+func quoteMySQLIdentifier(value string) string {
+	return "`" + strings.ReplaceAll(value, "`", "``") + "`"
 }

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/amap"
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/assistant"
@@ -19,6 +18,7 @@ import (
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/plugins/continuetask"
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/plugins/weather"
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/server"
+	"github.com/luoliwoshang/open-xiaoai-agent/internal/settings"
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/speaker"
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/tasks"
 )
@@ -55,6 +55,10 @@ func main() {
 	llmClient := llm.NewClient()
 	spk := speaker.New()
 	weatherClient := amap.NewClient(appConfig.AMap.APIKey)
+	settingsStore, err := settings.NewStore(dsn)
+	if err != nil {
+		log.Fatal(err)
+	}
 	taskManager, err := tasks.NewManager(dsn)
 	if err != nil {
 		log.Fatal(err)
@@ -78,10 +82,10 @@ func main() {
 		assistant.Config{
 			AbortAfterASR:         *abortAfterASR,
 			PostAbortDelay:        *postAbortDelay,
-			SessionWindow:         5 * time.Minute,
 			UseParallelIntentChat: *useParallelIntentChat,
 			StateDSN:              dsn,
 		},
+		settingsStore,
 		llm.NewIntentRecognizer(llmClient, appConfig.Intent, plugins, taskManager),
 		llm.NewReplyGenerator(llmClient, appConfig.Reply, appConfig.Soul),
 		plugins,
@@ -94,7 +98,7 @@ func main() {
 
 	srv := server.New(cfg, asrService.OnASR)
 	go func() {
-		if err := dashboard.New(*dashboardAddr, taskManager, complexTaskService, asrService).ListenAndServe(); err != nil {
+		if err := dashboard.New(*dashboardAddr, taskManager, complexTaskService, asrService, settingsStore).ListenAndServe(); err != nil {
 			log.Printf("dashboard stopped: %v", err)
 		}
 	}()

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,11 +1,22 @@
 import { useEffect, useMemo, useState } from 'react'
-import type { ClaudeRecord, ConversationSnapshot, DashboardState, Task, TaskEvent, TaskState } from './types'
+import type {
+  ClaudeRecord,
+  ConversationSnapshot,
+  DashboardState,
+  SessionSettings,
+  Task,
+  TaskEvent,
+  TaskState,
+} from './types'
 
 const emptyState: DashboardState = {
   tasks: [],
   events: [],
   claude_records: [],
   conversations: [],
+  settings: {
+    session_window_seconds: 300,
+  },
 }
 
 const stateLabels: Record<TaskState, string> = {
@@ -42,6 +53,11 @@ export default function App() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null)
+  const [windowInput, setWindowInput] = useState('300')
+  const [windowDirty, setWindowDirty] = useState(false)
+  const [settingsSaving, setSettingsSaving] = useState(false)
+  const [settingsFeedback, setSettingsFeedback] = useState<string | null>(null)
+  const [settingsError, setSettingsError] = useState<string | null>(null)
 
   useEffect(() => {
     let active = true
@@ -61,6 +77,7 @@ export default function App() {
             ...conversation,
             messages: conversation?.messages ?? [],
           })),
+          settings: normalizeSettings(raw.settings),
         }
         if (!active) return
         setData(next)
@@ -82,6 +99,11 @@ export default function App() {
       window.clearInterval(timer)
     }
   }, [])
+
+  useEffect(() => {
+    if (windowDirty || settingsSaving) return
+    setWindowInput(String(data.settings.session_window_seconds))
+  }, [data.settings.session_window_seconds, settingsSaving, windowDirty])
 
   const metrics = useMemo(() => {
     const completed = countByState(data.tasks, 'completed')
@@ -134,6 +156,46 @@ export default function App() {
     }
     setSelectedTaskId(data.tasks[0].id)
   }, [data.tasks, selectedTaskId])
+
+  async function saveSessionWindowSettings() {
+    const nextValue = Number(windowInput)
+    if (!Number.isInteger(nextValue)) {
+      setSettingsError('请输入整数秒数。')
+      setSettingsFeedback(null)
+      return
+    }
+
+    setSettingsSaving(true)
+    setSettingsError(null)
+    setSettingsFeedback(null)
+
+    try {
+      const response = await fetch('/api/settings/session', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ window_seconds: nextValue }),
+      })
+      if (!response.ok) {
+        throw new Error(await response.text())
+      }
+
+      const payload = (await response.json()) as { session?: SessionSettings }
+      const nextSettings = normalizeSettings(payload.session)
+      setData((current) => ({
+        ...current,
+        settings: nextSettings,
+      }))
+      setWindowInput(String(nextSettings.session_window_seconds))
+      setWindowDirty(false)
+      setSettingsFeedback('已保存，后续请求会立即按新的滑动窗口秒数生效。')
+    } catch (err) {
+      setSettingsError(err instanceof Error ? err.message : '保存失败')
+    } finally {
+      setSettingsSaving(false)
+    }
+  }
 
   return (
     <div className="app-shell">
@@ -266,6 +328,53 @@ export default function App() {
         </section>
 
         <aside className="panel panel-side">
+          <section className="focus-card settings-card">
+            <div className="focus-card-head">
+              <div>
+                <p className="eyebrow">SESSION SETTINGS</p>
+                <h3>会话窗口</h3>
+                <p>当前只保留滑动窗口策略。这里控制的是最近活跃多久后，系统才把上下文切到新会话。</p>
+              </div>
+              <span className="badge badge-running">滑动窗口</span>
+            </div>
+
+            <div className="settings-form">
+              <label className="settings-field">
+                <span>会话窗口秒数</span>
+                <input
+                  className="settings-input"
+                  inputMode="numeric"
+                  min={30}
+                  max={3600}
+                  step={1}
+                  type="number"
+                  value={windowInput}
+                  onChange={(event) => {
+                    setWindowInput(event.target.value)
+                    setWindowDirty(true)
+                    setSettingsFeedback(null)
+                    setSettingsError(null)
+                  }}
+                />
+              </label>
+
+              <div className="settings-actions">
+                <button
+                  className="settings-button"
+                  disabled={settingsSaving || !windowDirty}
+                  onClick={() => void saveSessionWindowSettings()}
+                  type="button"
+                >
+                  {settingsSaving ? '保存中...' : '保存设置'}
+                </button>
+                <span className="settings-note">建议范围 30 - 3600 秒，默认值 300 秒。</span>
+              </div>
+
+              {settingsFeedback ? <div className="settings-feedback">{settingsFeedback}</div> : null}
+              {settingsError ? <div className="error-banner settings-error">{settingsError}</div> : null}
+            </div>
+          </section>
+
           <section className="timeline-card">
             <div className="panel-head compact">
               <div>
@@ -386,4 +495,10 @@ export default function App() {
       </main>
     </div>
   )
+}
+
+function normalizeSettings(raw: Partial<SessionSettings> | undefined): SessionSettings {
+  return {
+    session_window_seconds: raw?.session_window_seconds ?? 300,
+  }
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -390,6 +390,10 @@ code {
   gap: 20px;
 }
 
+.settings-card {
+  margin-bottom: 0;
+}
+
 .focus-card {
   margin-bottom: 18px;
   padding: 18px;
@@ -422,6 +426,80 @@ code {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 14px;
+}
+
+.settings-form {
+  display: grid;
+  gap: 14px;
+}
+
+.settings-field {
+  display: grid;
+  gap: 8px;
+}
+
+.settings-field span,
+.settings-note {
+  color: rgba(237, 242, 255, 0.66);
+  line-height: 1.6;
+}
+
+.settings-input {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  padding: 14px 16px;
+  color: #edf2ff;
+  background: rgba(5, 11, 20, 0.86);
+  font: inherit;
+}
+
+.settings-input:focus {
+  outline: none;
+  border-color: rgba(42, 234, 196, 0.46);
+  box-shadow: 0 0 0 4px rgba(42, 234, 196, 0.08);
+}
+
+.settings-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.settings-button {
+  border: 0;
+  border-radius: 999px;
+  padding: 12px 18px;
+  color: #041019;
+  background: linear-gradient(135deg, #2aeac4 0%, #ffc062 100%);
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    transform 180ms ease,
+    opacity 180ms ease;
+}
+
+.settings-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.settings-button:disabled {
+  opacity: 0.52;
+  cursor: not-allowed;
+}
+
+.settings-feedback {
+  padding: 14px 16px;
+  border-radius: 16px;
+  color: #b8ffe0;
+  background: rgba(42, 234, 196, 0.08);
+  border: 1px solid rgba(42, 234, 196, 0.18);
+}
+
+.settings-error {
+  margin-bottom: 0;
 }
 
 .conversation-list {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -26,6 +26,11 @@ export type DashboardState = {
   events: TaskEvent[]
   claude_records: ClaudeRecord[]
   conversations: ConversationSnapshot[]
+  settings: SessionSettings
+}
+
+export type SessionSettings = {
+  session_window_seconds: number
 }
 
 export type ConversationMessage = {


### PR DESCRIPTION
## Summary

- add a MySQL-backed runtime settings store with `session.window_seconds`
- switch conversation reuse to a sliding window based on `last_active`
- expose dashboard APIs and UI for updating the session window seconds
- bootstrap the runtime database, tables, and default session setting at startup

## Testing

- `GOCACHE=$(pwd)/.gocache go test ./...`
- `npm run build:web`

Closes #2
