### PR TITLE
修复数据库配置入口分叉，只保留 config.yaml

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,6 @@ Only the high-signal parts are listed here.
 Run both backend and frontend:
 
 ```sh
-export OPEN_XIAOAI_AGENT_DSN='user:pass@tcp(127.0.0.1:3306)/open_xiaoai_agent'
 npm install
 npm run dev
 ```
@@ -125,9 +124,6 @@ Common backend flags from `main.go`:
   - default `:4399`
 - `-dashboard-addr`
   - default `:8090`
-- `-db-dsn`
-  - runtime database DSN
-  - if omitted, the process falls back to env var `OPEN_XIAOAI_AGENT_DSN`
 - `-claude-cwd`
   - working directory for Claude CLI tasks
 - `-debug`
@@ -150,6 +146,7 @@ Common backend flags from `main.go`:
 
 Config domains currently used:
 
+- `database.dsn`
 - `openai.base_url`
 - `intent.model / base_url / api_key`
 - `reply.model / base_url / api_key`
@@ -159,6 +156,7 @@ Important:
 
 - `config.yaml` is intentionally ignored
 - do not commit real API keys
+- runtime database config is sourced only from `config.yaml` field `database.dsn`
 
 ## Persistent State
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ cp config.example.yaml config.yaml
 2. 按需修改 `config.yaml`：
 
 ```yaml
+database:
+  dsn: user:pass@tcp(127.0.0.1:3306)/open_xiaoai_agent
+
 openai:
   base_url: https://api.openai.com/v1
 
@@ -146,13 +149,9 @@ reply:
 
 `SOUL.md` 会在启动时一并读取，用于定义主回复的人设。`config.yaml` 已被忽略，不要提交真实密钥。
 
-3. 设置运行时数据库 DSN：
+`database.dsn` 是当前唯一的数据库配置入口，启动时会直接从 `config.yaml` 读取。
 
-```sh
-export OPEN_XIAOAI_AGENT_DSN='user:pass@tcp(127.0.0.1:3306)/open_xiaoai_agent'
-```
-
-4. 安装依赖并启动：
+3. 直接启动：
 
 ```sh
 npm install
@@ -226,7 +225,7 @@ npm run dev:web
 npm run build:web
 ```
 
-更多后端参数可用 `go run . -h` 查看，常见的有 `-addr`、`-dashboard-addr`、`-db-dsn`、`-abort-after-asr`、`-parallel-intent-chat`。如果不传 `-db-dsn`，程序会读取 `OPEN_XIAOAI_AGENT_DSN`。
+更多后端参数可用 `go run . -h` 查看，常见的有 `-addr`、`-dashboard-addr`、`-abort-after-asr`、`-parallel-intent-chat`。数据库连接固定从 `config.yaml` 的 `database.dsn` 读取。
 
 ## Dashboard API
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,3 +1,6 @@
+database:
+  dsn: user:pass@tcp(127.0.0.1:3306)/open_xiaoai_agent
+
 openai:
   base_url: https://api.openai.com/v1
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,9 @@ type ModelConfig struct {
 }
 
 type FileConfig struct {
+	Database struct {
+		DSN string `yaml:"dsn"`
+	} `yaml:"database"`
 	OpenAI struct {
 		BaseURL string `yaml:"base_url"`
 	} `yaml:"openai"`
@@ -62,6 +65,10 @@ func Load(rootDir string) (*AppConfig, error) {
 }
 
 func (c *AppConfig) normalize() error {
+	c.Database.DSN = strings.TrimSpace(c.Database.DSN)
+	if c.Database.DSN == "" {
+		return fmt.Errorf("database.dsn is required")
+	}
 	defaultBaseURL := strings.TrimRight(strings.TrimSpace(c.OpenAI.BaseURL), "/")
 	if defaultBaseURL == "" {
 		defaultBaseURL = "https://api.openai.com/v1"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,6 +15,8 @@ func TestLoad(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "SOUL.md"), "# 角色\n你是一个有边界感的语音助手。")
 	writeFile(t, filepath.Join(dir, "config.yaml"), `
+database:
+  dsn: user:pass@tcp(127.0.0.1:3306)/open_xiaoai_agent
 openai:
   base_url: https://api.openai.com/v1
 amap:
@@ -36,6 +38,9 @@ reply:
 
 	if cfg.OpenAI.BaseURL != "https://api.openai.com/v1" {
 		t.Fatalf("openai.base_url = %q", cfg.OpenAI.BaseURL)
+	}
+	if cfg.Database.DSN != "user:pass@tcp(127.0.0.1:3306)/open_xiaoai_agent" {
+		t.Fatalf("database.dsn = %q", cfg.Database.DSN)
 	}
 	if cfg.AMap.APIKey != "amap-key" {
 		t.Fatalf("amap.api_key = %q", cfg.AMap.APIKey)
@@ -63,6 +68,8 @@ func TestLoad_AllowsEmptyAMapKey(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "SOUL.md"), "# 角色\n你是一个有边界感的语音助手。")
 	writeFile(t, filepath.Join(dir, "config.yaml"), `
+database:
+  dsn: user:pass@tcp(127.0.0.1:3306)/open_xiaoai_agent
 openai:
   base_url: https://api.openai.com/v1
 amap:
@@ -90,6 +97,8 @@ func TestLoad_DefaultsModelBaseURLFromOpenAI(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "SOUL.md"), "# 角色\n你是一个有边界感的语音助手。")
 	writeFile(t, filepath.Join(dir, "config.yaml"), `
+database:
+  dsn: user:pass@tcp(127.0.0.1:3306)/open_xiaoai_agent
 openai:
   base_url: https://api.openai.com/v1
 intent:
@@ -113,12 +122,61 @@ reply:
 	}
 }
 
+func TestLoad_TrimsDatabaseDSN(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "SOUL.md"), "# 角色\n你是一个有边界感的语音助手。")
+	writeFile(t, filepath.Join(dir, "config.yaml"), `
+database:
+  dsn: "  user:pass@tcp(127.0.0.1:3306)/open_xiaoai_agent  "
+openai:
+  base_url: https://api.openai.com/v1
+intent:
+  model: gpt-4.1-mini
+  api_key: intent-key
+reply:
+  model: gpt-4.1
+  api_key: reply-key
+`)
+
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Database.DSN != "user:pass@tcp(127.0.0.1:3306)/open_xiaoai_agent" {
+		t.Fatalf("database.dsn = %q", cfg.Database.DSN)
+	}
+}
+
 func TestLoad_RejectsEmptySoul(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "SOUL.md"), "   \n")
-	writeFile(t, filepath.Join(dir, "config.yaml"), "openai:\n  base_url: https://api.openai.com/v1\n")
+	writeFile(t, filepath.Join(dir, "config.yaml"), "database:\n  dsn: user:pass@tcp(127.0.0.1:3306)/open_xiaoai_agent\nopenai:\n  base_url: https://api.openai.com/v1\n")
+
+	_, err := config.Load(dir)
+	if err == nil {
+		t.Fatal("Load() error = nil, want non-nil")
+	}
+}
+
+func TestLoad_RejectsMissingDatabaseDSN(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "SOUL.md"), "# 角色\n你是一个有边界感的语音助手。")
+	writeFile(t, filepath.Join(dir, "config.yaml"), `
+openai:
+  base_url: https://api.openai.com/v1
+intent:
+  model: gpt-4.1-mini
+  api_key: intent-key
+reply:
+  model: gpt-4.1
+  api_key: reply-key
+`)
 
 	_, err := config.Load(dir)
 	if err == nil {
@@ -132,6 +190,8 @@ func TestLoad_RejectsMissingModelConfig(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "SOUL.md"), "# 角色\n你是一个有边界感的语音助手。")
 	writeFile(t, filepath.Join(dir, "config.yaml"), `
+database:
+  dsn: user:pass@tcp(127.0.0.1:3306)/open_xiaoai_agent
 openai:
   base_url: https://api.openai.com/v1
 intent:

--- a/main.go
+++ b/main.go
@@ -27,7 +27,6 @@ import (
 func main() {
 	addr := flag.String("addr", ":4399", "websocket listen address")
 	dashboardAddr := flag.String("dashboard-addr", ":8090", "dashboard listen address")
-	dbDSN := flag.String("db-dsn", "", "runtime database DSN, expected to be a MySQL DSN such as user:pass@tcp(127.0.0.1:3306)/open_xiaoai_agent")
 	claudeCwd := flag.String("claude-cwd", "", "working directory for claude complex tasks")
 	debug := flag.Bool("debug", false, "print raw events for debugging")
 	abortAfterASR := flag.Bool("abort-after-asr", true, "abort original XiaoAI immediately before intent stage")
@@ -39,18 +38,12 @@ func main() {
 		Addr:  *addr,
 		Debug: *debug,
 	}
-	dsn := strings.TrimSpace(*dbDSN)
-	if dsn == "" {
-		dsn = strings.TrimSpace(os.Getenv("OPEN_XIAOAI_AGENT_DSN"))
-	}
 
 	appConfig, err := config.Load(".")
 	if err != nil {
 		log.Fatal(err)
 	}
-	if dsn == "" {
-		log.Fatal("db-dsn is required, or set OPEN_XIAOAI_AGENT_DSN")
-	}
+	dsn := appConfig.Database.DSN
 	log.Printf("loaded SOUL.md (%d chars)", len(appConfig.Soul))
 	log.Printf("loaded models: intent=%s reply=%s", appConfig.Intent.Model, appConfig.Reply.Model)
 	llmClient := llm.NewClient()


### PR DESCRIPTION
## 变更说明

本 PR 将数据库配置入口收敛为单一来源，只保留 `config.yaml` 中的 `database.dsn`。

主要调整：

- 删除 `-db-dsn` 启动参数
- 删除 `OPEN_XIAOAI_AGENT_DSN` 环境变量兜底
- 启动时固定从 `config.yaml` 读取 `database.dsn`
- `database.dsn` 缺失时，在配置加载阶段直接报错
- 同步更新示例配置、README 和 AGENTS 开发说明
- 补充配置测试，覆盖数据库 DSN 加载、裁剪和缺失校验

## 验证

- `GOCACHE=$(pwd)/.gocache go test ./...`
- `npm run build:web`
- `go run . -h`

Closes #6
