### PR TITLE
优化设置页结构：改为左侧菜单切换系统设置与 IM 配置

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -439,6 +439,7 @@ Important routes:
 - `POST /api/settings/im-delivery`
 - `POST /api/im/wechat/login/start`
 - `GET /api/im/wechat/login/status`
+- `POST /api/im/wechat/login/confirm`
 - `POST /api/im/targets`
 - `POST /api/im/targets/default`
 - `POST /api/im/targets/delete`

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ flowchart TD
 - 提供独立的 React + Vite dashboard
 - 使用 MySQL 保存任务、会话和插件私有状态
 - 会话上下文默认使用滑动窗口，并支持在 Dashboard 中调整窗口秒数
-- 提供第一期独立 IM Gateway：支持微信扫码登录、多账号管理、文本触达配置
+- 提供第一期独立 IM Gateway：支持微信扫码登录、确认添加账号、多账号管理、文本触达配置
 - 支持把小爱的正常回复异步镜像到选中的微信私聊目标，不阻塞设备侧播报
 
 当前内置工具：
@@ -253,7 +253,11 @@ Go 后端只提供 API，前端位于 `web/`。
 - `POST /api/settings/im-delivery`
 - `POST /api/im/wechat/login/start`
 - `GET /api/im/wechat/login/status`
+- `POST /api/im/wechat/login/confirm`
 - `POST /api/im/targets`
+- `POST /api/im/targets/default`
+- `POST /api/im/targets/delete`
+- `POST /api/im/accounts/delete`
 - `POST /api/reset`
 
 ## 验证

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -29,6 +29,7 @@ type Server struct {
 		Snapshot() im.Snapshot
 		StartWeChatLogin() (im.WeChatLoginStart, error)
 		PollWeChatLogin(sessionKey string) (im.WeChatLoginStatus, error)
+		ConfirmWeChatLogin(sessionKey string) (im.Account, error)
 		UpsertTarget(accountID string, name string, targetUserID string, setDefault bool) (im.Target, error)
 		SetDefaultTarget(accountID string, targetID string) error
 		DeleteTarget(targetID string) error
@@ -48,6 +49,7 @@ func New(addr string, tasks *tasks.Manager, claude *complextask.Service, convers
 	Snapshot() im.Snapshot
 	StartWeChatLogin() (im.WeChatLoginStart, error)
 	PollWeChatLogin(sessionKey string) (im.WeChatLoginStatus, error)
+	ConfirmWeChatLogin(sessionKey string) (im.Account, error)
 	UpsertTarget(accountID string, name string, targetUserID string, setDefault bool) (im.Target, error)
 	SetDefaultTarget(accountID string, targetID string) error
 	DeleteTarget(targetID string) error
@@ -74,6 +76,7 @@ func (s *Server) ListenAndServe() error {
 	mux.HandleFunc("/api/settings/im-delivery", s.handleIMDeliverySettings)
 	mux.HandleFunc("/api/im/wechat/login/start", s.handleWeChatLoginStart)
 	mux.HandleFunc("/api/im/wechat/login/status", s.handleWeChatLoginStatus)
+	mux.HandleFunc("/api/im/wechat/login/confirm", s.handleWeChatLoginConfirm)
 	mux.HandleFunc("/api/im/targets", s.handleIMTargets)
 	mux.HandleFunc("/api/im/targets/default", s.handleIMTargetDefault)
 	mux.HandleFunc("/api/im/targets/delete", s.handleIMTargetDelete)
@@ -239,6 +242,36 @@ func (s *Server) handleWeChatLoginStatus(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, map[string]any{
 		"ok":     true,
 		"status": status,
+	})
+}
+
+func (s *Server) handleWeChatLoginConfirm(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.im == nil {
+		http.Error(w, "im gateway is not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	var payload struct {
+		SessionKey string `json:"session_key"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, fmt.Sprintf("decode wechat login confirm payload: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	account, err := s.im.ConfirmWeChatLogin(payload.SessionKey)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	writeJSON(w, map[string]any{
+		"ok":      true,
+		"account": account,
 	})
 }
 

--- a/internal/dashboard/server_test.go
+++ b/internal/dashboard/server_test.go
@@ -60,6 +60,8 @@ func (f *fakeSettings) UpdateIMDelivery(enabled bool, accountID string, targetID
 type fakeIM struct {
 	snapshot        im.Snapshot
 	lastDeliveryCfg settings.Snapshot
+	confirmAccount  im.Account
+	confirmSession  string
 	resetCalls      int
 }
 
@@ -73,6 +75,21 @@ func (f *fakeIM) StartWeChatLogin() (im.WeChatLoginStart, error) {
 
 func (f *fakeIM) PollWeChatLogin(sessionKey string) (im.WeChatLoginStatus, error) {
 	return im.WeChatLoginStatus{Status: "pending", Message: sessionKey}, nil
+}
+
+func (f *fakeIM) ConfirmWeChatLogin(sessionKey string) (im.Account, error) {
+	f.confirmSession = sessionKey
+	if f.confirmAccount.ID == "" {
+		f.confirmAccount = im.Account{
+			ID:              "account_1",
+			Platform:        im.PlatformWeChat,
+			RemoteAccountID: "bot@im.bot",
+			OwnerUserID:     "user@im.wechat",
+			DisplayName:     "bot@im.bot",
+			BaseURL:         "https://example.com",
+		}
+	}
+	return f.confirmAccount, nil
 }
 
 func (f *fakeIM) UpsertTarget(accountID string, name string, targetUserID string, setDefault bool) (im.Target, error) {
@@ -241,5 +258,37 @@ func TestHandleSessionSettingsRejectsInvalidValue(t *testing.T) {
 
 	if recorder.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleWeChatLoginConfirmPersistsAfterExplicitConfirmation(t *testing.T) {
+	t.Parallel()
+
+	imGateway := &fakeIM{}
+	server := New(":0", nil, nil, nil, &fakeSettings{snapshot: settings.Snapshot{SessionWindowSeconds: 300}}, imGateway)
+	req := httptest.NewRequest(http.MethodPost, "/api/im/wechat/login/confirm", strings.NewReader(`{"session_key":"sess-1"}`))
+	recorder := httptest.NewRecorder()
+
+	server.handleWeChatLoginConfirm(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if imGateway.confirmSession != "sess-1" {
+		t.Fatalf("confirmSession = %q, want sess-1", imGateway.confirmSession)
+	}
+
+	var payload struct {
+		OK      bool       `json:"ok"`
+		Account im.Account `json:"account"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if !payload.OK {
+		t.Fatal("OK = false, want true")
+	}
+	if payload.Account.RemoteAccountID != "bot@im.bot" {
+		t.Fatalf("RemoteAccountID = %q, want bot@im.bot", payload.Account.RemoteAccountID)
 	}
 }

--- a/internal/im/model.go
+++ b/internal/im/model.go
@@ -57,8 +57,15 @@ type WeChatLoginStart struct {
 	ExpiresAt     time.Time `json:"expires_at"`
 }
 
+type WeChatLoginCandidate struct {
+	RemoteAccountID string `json:"remote_account_id"`
+	OwnerUserID     string `json:"owner_user_id"`
+	DisplayName     string `json:"display_name"`
+	BaseURL         string `json:"base_url"`
+}
+
 type WeChatLoginStatus struct {
-	Status  string   `json:"status"`
-	Message string   `json:"message"`
-	Account *Account `json:"account,omitempty"`
+	Status    string                `json:"status"`
+	Message   string                `json:"message"`
+	Candidate *WeChatLoginCandidate `json:"candidate,omitempty"`
 }

--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/settings"
@@ -20,13 +21,20 @@ type Service struct {
 	settings runtimeSettings
 	adapters map[string]Adapter
 
-	deliveries chan deliveryRequest
+	pendingMu     sync.Mutex
+	pendingLogins map[string]pendingWeChatLogin
+	deliveries    chan deliveryRequest
 }
 
 type deliveryRequest struct {
 	AccountID string
 	TargetID  string
 	Text      string
+}
+
+type pendingWeChatLogin struct {
+	Result      WeChatLoginResult
+	ConfirmedAt time.Time
 }
 
 func NewService(dsn string, runtimeSettings runtimeSettings) (*Service, error) {
@@ -41,7 +49,8 @@ func NewService(dsn string, runtimeSettings runtimeSettings) (*Service, error) {
 		adapters: map[string]Adapter{
 			PlatformWeChat: NewWeChatAdapter(),
 		},
-		deliveries: make(chan deliveryRequest, 32),
+		pendingLogins: make(map[string]pendingWeChatLogin),
+		deliveries:    make(chan deliveryRequest, 32),
 	}
 	go svc.runDeliveryLoop()
 	return svc, nil
@@ -70,6 +79,18 @@ func (s *Service) StartWeChatLogin() (WeChatLoginStart, error) {
 }
 
 func (s *Service) PollWeChatLogin(sessionKey string) (WeChatLoginStatus, error) {
+	sessionKey = strings.TrimSpace(sessionKey)
+	if sessionKey == "" {
+		return WeChatLoginStatus{}, fmt.Errorf("wechat login session key is required")
+	}
+	if pending, ok := s.getPendingWeChatLogin(sessionKey); ok {
+		return WeChatLoginStatus{
+			Status:    pending.Status,
+			Message:   pending.Message,
+			Candidate: buildWeChatLoginCandidate(pending),
+		}, nil
+	}
+
 	adapter, ok := s.adapters[PlatformWeChat]
 	if !ok {
 		return WeChatLoginStatus{}, fmt.Errorf("wechat adapter is not configured")
@@ -91,6 +112,26 @@ func (s *Service) PollWeChatLogin(sessionKey string) (WeChatLoginStatus, error) 
 		return status, nil
 	}
 
+	s.rememberPendingWeChatLogin(sessionKey, result)
+	status.Candidate = buildWeChatLoginCandidate(result)
+	return status, nil
+}
+
+func (s *Service) ConfirmWeChatLogin(sessionKey string) (Account, error) {
+	if s == nil || s.store == nil {
+		return Account{}, fmt.Errorf("im service is not configured")
+	}
+
+	sessionKey = strings.TrimSpace(sessionKey)
+	if sessionKey == "" {
+		return Account{}, fmt.Errorf("wechat login session key is required")
+	}
+
+	result, ok := s.getPendingWeChatLogin(sessionKey)
+	if !ok {
+		return Account{}, fmt.Errorf("当前扫码结果不存在或已失效，请重新发起登录")
+	}
+
 	account, err := s.store.UpsertAccount(
 		PlatformWeChat,
 		result.RemoteAccountID,
@@ -100,17 +141,17 @@ func (s *Service) PollWeChatLogin(sessionKey string) (WeChatLoginStatus, error) 
 		result.Token,
 	)
 	if err != nil {
-		return WeChatLoginStatus{}, err
+		return Account{}, err
 	}
 	if _, err := s.store.EnsureOwnerTarget(account.ID, result.OwnerUserID); err != nil {
-		return WeChatLoginStatus{}, err
+		return Account{}, err
 	}
 	if err := s.store.AppendEvent(account.ID, "login", "微信账号登录成功"); err != nil {
 		log.Printf("append im login event failed: %v", err)
 	}
 
-	status.Account = &account
-	return status, nil
+	s.deletePendingWeChatLogin(sessionKey)
+	return account, nil
 }
 
 func (s *Service) UpsertTarget(accountID string, name string, targetUserID string, setDefault bool) (Target, error) {
@@ -231,6 +272,9 @@ func (s *Service) Reset() error {
 			return err
 		}
 	}
+	s.pendingMu.Lock()
+	s.pendingLogins = make(map[string]pendingWeChatLogin)
+	s.pendingMu.Unlock()
 	return nil
 }
 
@@ -336,4 +380,60 @@ func trimForEvent(text string) string {
 	}
 	runes := []rune(text)
 	return string(runes[:limit]) + "..."
+}
+
+func (s *Service) getPendingWeChatLogin(sessionKey string) (WeChatLoginResult, bool) {
+	if s == nil {
+		return WeChatLoginResult{}, false
+	}
+
+	s.pendingMu.Lock()
+	defer s.pendingMu.Unlock()
+
+	pending, ok := s.pendingLogins[sessionKey]
+	if !ok {
+		return WeChatLoginResult{}, false
+	}
+	if time.Since(pending.ConfirmedAt) > 30*time.Minute {
+		delete(s.pendingLogins, sessionKey)
+		return WeChatLoginResult{}, false
+	}
+	return pending.Result, true
+}
+
+func (s *Service) rememberPendingWeChatLogin(sessionKey string, result WeChatLoginResult) {
+	if s == nil {
+		return
+	}
+
+	s.pendingMu.Lock()
+	defer s.pendingMu.Unlock()
+
+	s.pendingLogins[sessionKey] = pendingWeChatLogin{
+		Result:      result,
+		ConfirmedAt: time.Now(),
+	}
+}
+
+func (s *Service) deletePendingWeChatLogin(sessionKey string) {
+	if s == nil {
+		return
+	}
+
+	s.pendingMu.Lock()
+	defer s.pendingMu.Unlock()
+
+	delete(s.pendingLogins, sessionKey)
+}
+
+func buildWeChatLoginCandidate(result WeChatLoginResult) *WeChatLoginCandidate {
+	if strings.TrimSpace(result.RemoteAccountID) == "" {
+		return nil
+	}
+	return &WeChatLoginCandidate{
+		RemoteAccountID: strings.TrimSpace(result.RemoteAccountID),
+		OwnerUserID:     strings.TrimSpace(result.OwnerUserID),
+		DisplayName:     strings.TrimSpace(result.RemoteAccountID),
+		BaseURL:         strings.TrimSpace(result.BaseURL),
+	}
 }

--- a/internal/im/service_test.go
+++ b/internal/im/service_test.go
@@ -12,9 +12,11 @@ import (
 )
 
 type stubAdapter struct {
-	mu       sync.Mutex
-	sendErr  error
-	messages []string
+	mu          sync.Mutex
+	sendErr     error
+	loginErr    error
+	loginResult WeChatLoginResult
+	messages    []string
 }
 
 func (s *stubAdapter) Platform() string {
@@ -26,7 +28,10 @@ func (s *stubAdapter) StartLogin(ctx context.Context) (WeChatLoginStart, error) 
 }
 
 func (s *stubAdapter) PollLogin(ctx context.Context, sessionKey string) (WeChatLoginResult, error) {
-	return WeChatLoginResult{}, nil
+	if s.loginErr != nil {
+		return WeChatLoginResult{}, s.loginErr
+	}
+	return s.loginResult, nil
 }
 
 func (s *stubAdapter) SendText(ctx context.Context, account Account, target Target, text string) (TextSendResult, error) {
@@ -79,6 +84,75 @@ func TestServiceUpdateDeliveryConfigPersistsSelection(t *testing.T) {
 	}
 	if snapshot.IMSelectedTargetID != target.ID {
 		t.Fatalf("IMSelectedTargetID = %q, want %q", snapshot.IMSelectedTargetID, target.ID)
+	}
+}
+
+func TestServiceConfirmWeChatLoginPersistsAccountAfterExplicitConfirmation(t *testing.T) {
+	t.Parallel()
+
+	dsn := testmysql.NewDSN(t)
+	settingsStore, err := settings.NewStore(dsn)
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	service, err := NewService(dsn, settingsStore)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	adapter := &stubAdapter{
+		loginResult: WeChatLoginResult{
+			Status:          "confirmed",
+			Message:         "微信账号登录成功。",
+			RemoteAccountID: "bot@im.bot",
+			OwnerUserID:     "user@im.wechat",
+			BaseURL:         "https://example.com",
+			Token:           "token",
+		},
+	}
+	service.adapters[PlatformWeChat] = adapter
+
+	status, err := service.PollWeChatLogin("session-1")
+	if err != nil {
+		t.Fatalf("PollWeChatLogin() error = %v", err)
+	}
+	if status.Status != "confirmed" {
+		t.Fatalf("status = %q, want confirmed", status.Status)
+	}
+	if status.Candidate == nil {
+		t.Fatal("Candidate = nil, want candidate data")
+	}
+
+	accounts, err := service.store.ListAccounts()
+	if err != nil {
+		t.Fatalf("ListAccounts() error = %v", err)
+	}
+	if len(accounts) != 0 {
+		t.Fatalf("ListAccounts() len = %d, want 0 before confirmation", len(accounts))
+	}
+
+	account, err := service.ConfirmWeChatLogin("session-1")
+	if err != nil {
+		t.Fatalf("ConfirmWeChatLogin() error = %v", err)
+	}
+	if account.RemoteAccountID != "bot@im.bot" {
+		t.Fatalf("RemoteAccountID = %q, want bot@im.bot", account.RemoteAccountID)
+	}
+
+	accounts, err = service.store.ListAccounts()
+	if err != nil {
+		t.Fatalf("ListAccounts() error = %v", err)
+	}
+	if len(accounts) != 1 {
+		t.Fatalf("ListAccounts() len = %d, want 1 after confirmation", len(accounts))
+	}
+
+	targets, err := service.store.ListTargets()
+	if err != nil {
+		t.Fatalf("ListTargets() error = %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("ListTargets() len = %d, want 1 auto-created owner target", len(targets))
 	}
 }
 

--- a/web/src/components/settings/IMDeliveryPanel.tsx
+++ b/web/src/components/settings/IMDeliveryPanel.tsx
@@ -31,6 +31,9 @@ export function IMDeliveryPanel({
   onTargetChange,
   onSave,
 }: Props) {
+  const hasAccounts = accounts.length > 0
+  const hasTargets = targets.length > 0
+
   return (
     <article className="panel settings-panel">
       <div className="panel-head compact">
@@ -54,38 +57,42 @@ export function IMDeliveryPanel({
           <span>激活微信账号</span>
           <select
             className="settings-select"
+            disabled={!hasAccounts}
             value={accountID}
             onChange={(event) => onAccountChange(event.target.value)}
           >
-            <option value="">请选择账号</option>
+            <option value="">{hasAccounts ? '请选择账号' : '请先配置带有触达目标的账号'}</option>
             {accounts.map((account) => (
               <option key={account.id} value={account.id}>
                 {account.display_name || account.remote_account_id}
               </option>
             ))}
           </select>
+          <span className="settings-note">这里只显示已经配置过触达目标的账号。</span>
         </label>
 
         <label className="settings-field">
           <span>默认触达对象</span>
           <select
             className="settings-select"
+            disabled={!accountID || !hasTargets}
             value={targetID}
             onChange={(event) => onTargetChange(event.target.value)}
           >
-            <option value="">请选择目标</option>
+            <option value="">{accountID ? (hasTargets ? '请选择目标' : '当前账号还没有已配置目标') : '请先选择账号'}</option>
             {targets.map((target) => (
               <option key={target.id} value={target.id}>
                 {target.name} · {target.target_user_id}
               </option>
             ))}
           </select>
+          <span className="settings-note">镜像投递只能选择已经在下方“触达目标管理”里配置好的对象。</span>
         </label>
 
         <div className="settings-actions">
           <button
             className="settings-button"
-            disabled={saving || !dirty}
+            disabled={saving || !dirty || (enabled && (!accountID || !targetID))}
             onClick={() => onSave()}
             type="button"
           >
@@ -100,4 +107,3 @@ export function IMDeliveryPanel({
     </article>
   )
 }
-

--- a/web/src/components/settings/WeChatAccountsPanel.tsx
+++ b/web/src/components/settings/WeChatAccountsPanel.tsx
@@ -3,10 +3,12 @@ import type { IMAccount } from '../../types'
 
 type Props = {
   accounts: IMAccount[]
+  loginBusy: boolean
+  onStartLogin: () => void
   onDeleteAccount: (accountID: string) => void
 }
 
-export function WeChatAccountsPanel({ accounts, onDeleteAccount }: Props) {
+export function WeChatAccountsPanel({ accounts, loginBusy, onStartLogin, onDeleteAccount }: Props) {
   return (
     <article className="panel settings-panel panel-wide">
       <div className="panel-head compact">
@@ -14,6 +16,9 @@ export function WeChatAccountsPanel({ accounts, onDeleteAccount }: Props) {
           <p className="eyebrow">WECHAT ACCOUNTS</p>
           <h3>账号管理</h3>
         </div>
+        <button className="settings-button" disabled={loginBusy} onClick={() => onStartLogin()} type="button">
+          {loginBusy ? '登录流程进行中...' : '新增微信账号'}
+        </button>
       </div>
 
       <div className="account-grid">
@@ -61,4 +66,3 @@ export function WeChatAccountsPanel({ accounts, onDeleteAccount }: Props) {
     </article>
   )
 }
-

--- a/web/src/components/settings/WeChatLoginPanel.tsx
+++ b/web/src/components/settings/WeChatLoginPanel.tsx
@@ -1,68 +1,127 @@
 import { formatTime } from '../../lib/dashboard'
+import type { WeChatLoginCandidate, WeChatLoginStatus } from '../../types'
 
 type Props = {
+  open: boolean
   loading: boolean
   polling: boolean
+  confirming: boolean
+  status: WeChatLoginStatus['status'] | null
   qrDataUrl: string | null
   qrRawText: string | null
   expiresAt: string | null
   message: string | null
   error: string | null
-  onStart: () => void
+  candidate: WeChatLoginCandidate | null
+  onClose: () => void
+  onConfirm: () => void
 }
 
 export function WeChatLoginPanel({
+  open,
   loading,
   polling,
+  confirming,
+  status,
   qrDataUrl,
   qrRawText,
   expiresAt,
   message,
   error,
-  onStart,
+  candidate,
+  onClose,
+  onConfirm,
 }: Props) {
+  if (!open) return null
+
+  const confirmed = status === 'confirmed' && candidate
+
   return (
-    <article className="panel settings-panel panel-wide">
-      <div className="panel-head compact">
-        <div>
-          <p className="eyebrow">WECHAT LOGIN</p>
-          <h3>微信扫码登录</h3>
-        </div>
-        <button className="settings-button" disabled={loading || polling} onClick={() => onStart()} type="button">
-          {loading ? '启动中...' : polling ? '等待扫码中' : '新增微信账号'}
-        </button>
-      </div>
-
-      <div className="settings-login-grid">
-        <div className="qr-card">
-          {qrDataUrl ? (
-            <img alt="微信登录二维码" className="qr-image" src={qrDataUrl} />
-          ) : (
-            <div className="empty-card qr-empty">点击右上角按钮后，这里会出现微信登录二维码。</div>
-          )}
+    <div className="settings-modal-backdrop" role="presentation">
+      <div aria-modal="true" className="settings-modal-card" role="dialog">
+        <div className="panel-head compact">
+          <div>
+            <p className="eyebrow">WECHAT LOGIN</p>
+            <h3>微信扫码登录</h3>
+          </div>
+          <button className="ghost-button" onClick={() => onClose()} type="button">
+            关闭
+          </button>
         </div>
 
-        <div className="login-copy">
-          <p className="settings-note">
-            当前阶段只做微信文本触达，不做 IM 入站会话。扫码成功后，会自动保存微信账号登录态，并尝试把扫码用户登记为默认触达对象。
-          </p>
-          {message ? <div className="settings-feedback">{message}</div> : null}
-          {error ? <div className="error-banner settings-error">{error}</div> : null}
-          {expiresAt ? (
-            <div className="task-meta">
-              <span>二维码过期时间</span>
-              <p>{formatTime(expiresAt)}</p>
+        {confirmed ? (
+          <div className="settings-login-confirm">
+            <p className="settings-note">
+              扫码授权已经完成。确认后，这个微信账号才会加入当前网关账号列表，并自动补一个“扫码用户”默认触达目标。
+            </p>
+
+            {message ? <div className="settings-feedback">{message}</div> : null}
+            {error ? <div className="error-banner settings-error">{error}</div> : null}
+
+            <div className="focus-grid">
+              <div className="task-meta">
+                <span>账号标识</span>
+                <p>{candidate.display_name || candidate.remote_account_id}</p>
+              </div>
+              <div className="task-meta">
+                <span>微信扫码用户</span>
+                <p>{candidate.owner_user_id || '—'}</p>
+              </div>
+              <div className="task-meta task-meta-wide">
+                <span>Base URL</span>
+                <p>{candidate.base_url || '—'}</p>
+              </div>
             </div>
-          ) : null}
-          {qrRawText ? (
-            <div className="task-meta task-meta-wide">
-              <span>二维码原始内容</span>
-              <p><code>{qrRawText}</code></p>
+
+            <div className="settings-actions">
+              <button className="settings-button" disabled={confirming} onClick={() => onConfirm()} type="button">
+                {confirming ? '添加中...' : '确认添加账号'}
+              </button>
+              <button className="ghost-button" disabled={confirming} onClick={() => onClose()} type="button">
+                暂不添加
+              </button>
             </div>
-          ) : null}
-        </div>
+          </div>
+        ) : (
+          <div className="settings-login-grid">
+            <div className="qr-card">
+              {qrDataUrl ? (
+                <img alt="微信登录二维码" className="qr-image" src={qrDataUrl} />
+              ) : (
+                <div className="empty-card qr-empty">
+                  {loading ? '正在准备二维码...' : '点击新增微信账号后，这里会出现登录二维码。'}
+                </div>
+              )}
+            </div>
+
+            <div className="login-copy">
+              <p className="settings-note">
+                当前阶段只做微信文本触达，不做 IM 入站会话。扫码确认后，界面会先展示待添加的账号信息，只有你点确认才会真正保存登录态。
+              </p>
+              {message ? <div className="settings-feedback">{message}</div> : null}
+              {error ? <div className="error-banner settings-error">{error}</div> : null}
+              {expiresAt ? (
+                <div className="task-meta">
+                  <span>二维码过期时间</span>
+                  <p>{formatTime(expiresAt)}</p>
+                </div>
+              ) : null}
+              {qrRawText ? (
+                <div className="task-meta task-meta-wide">
+                  <span>二维码原始内容</span>
+                  <p><code>{qrRawText}</code></p>
+                </div>
+              ) : null}
+
+              <div className="settings-actions">
+                <span className="settings-note">
+                  {loading ? '正在拉起微信登录流程。' : polling ? '等待扫码与确认，不会直接把账号写入系统。' : '关闭弹窗后可重新发起一次扫码。'}
+                </span>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
-    </article>
+    </div>
   )
 }
-

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -15,6 +15,15 @@ import type {
   WeChatLoginStatus,
 } from '../types'
 
+type SettingsSectionKey = 'system' | 'im'
+
+type SettingsSection = {
+  key: SettingsSectionKey
+  eyebrow: string
+  title: string
+  description: string
+}
+
 type LoginPanelState = {
   loading: boolean
   polling: boolean
@@ -39,6 +48,21 @@ const emptyLoginState: LoginPanelState = {
   error: null,
 }
 
+const settingsSections: SettingsSection[] = [
+  {
+    key: 'system',
+    eyebrow: 'SYSTEM',
+    title: '系统设置',
+    description: '管理会话窗口和全局运行期行为，适合放置 Agent 的基础配置。',
+  },
+  {
+    key: 'im',
+    eyebrow: 'IM GATEWAY',
+    title: 'IM 配置',
+    description: '单独管理微信登录、账号、触达目标和回复镜像，不再与系统设置混排。',
+  },
+]
+
 type Props = {
   data: DashboardState
   error: string | null
@@ -47,6 +71,7 @@ type Props = {
 }
 
 export function SettingsPage({ data, error, setData, refresh }: Props) {
+  const [activeSection, setActiveSection] = useState<SettingsSectionKey>('system')
   const [windowInput, setWindowInput] = useState('300')
   const [windowDirty, setWindowDirty] = useState(false)
   const [settingsSaving, setSettingsSaving] = useState(false)
@@ -155,6 +180,10 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
   const targetFormTargets = useMemo(() => {
     return data.im.targets.filter((target) => target.account_id === targetAccountID)
   }, [data.im.targets, targetAccountID])
+
+  const currentSection = useMemo(() => {
+    return settingsSections.find((section) => section.key === activeSection) ?? settingsSections[0]
+  }, [activeSection])
 
   async function saveSessionWindowSettings() {
     const nextValue = Number(windowInput)
@@ -316,21 +345,21 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
     <main className="settings-page">
       <section className="settings-hero-card">
         <div>
-          <p className="eyebrow">SYSTEM SETTINGS</p>
-          <h2>IM Gateway 与系统设置</h2>
+          <p className="eyebrow">SETTINGS CENTER</p>
+          <h2>把设置拆成清晰的配置域</h2>
           <p className="hero-text">
-            这里单独负责运行期设置和微信账号管理。第一期只做微信文本触达：
-            小爱的回复在设备播报成功后，会异步再镜像到你选中的微信目标。
+            设置页不再把所有配置堆成一个长滚动页面，而是按配置域分开管理。
+            左侧菜单负责切换，右侧只展示当前配置域的内容，让系统设置和 IM 配置各自独立。
           </p>
         </div>
         <div className="settings-hero-stats">
           <div className="metric-card metric-mint">
-            <span>微信账号</span>
-            <strong>{data.im.accounts.length}</strong>
+            <span>配置域</span>
+            <strong>{settingsSections.length}</strong>
           </div>
           <div className="metric-card metric-cyan">
-            <span>触达目标</span>
-            <strong>{data.im.targets.length}</strong>
+            <span>微信账号</span>
+            <strong>{data.im.accounts.length}</strong>
           </div>
           <div className="metric-card metric-amber">
             <span>镜像状态</span>
@@ -341,96 +370,137 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
 
       {error ? <div className="error-banner">接口异常：{error}</div> : null}
 
-      <section className="settings-grid-page">
-        <SessionSettingsPanel
-          settingsError={settingsError}
-          settingsFeedback={settingsFeedback}
-          settingsSaving={settingsSaving}
-          windowDirty={windowDirty}
-          windowInput={windowInput}
-          onSave={() => void saveSessionWindowSettings()}
-          onWindowInputChange={(value) => {
-            setWindowInput(value)
-            setWindowDirty(true)
-            setSettingsFeedback(null)
-            setSettingsError(null)
-          }}
-        />
+      <section className="settings-workspace">
+        <aside className="panel settings-nav-card">
+          <div className="panel-head compact">
+            <div>
+              <p className="eyebrow">SETTINGS MAP</p>
+              <h3>配置导航</h3>
+            </div>
+          </div>
 
-        <IMDeliveryPanel
-          accountID={deliveryAccountID}
-          accounts={data.im.accounts}
-          dirty={deliveryDirty}
-          enabled={deliveryEnabled}
-          error={deliveryError}
-          feedback={deliveryFeedback}
-          saving={deliverySaving}
-          targetID={deliveryTargetID}
-          targets={deliveryTargets}
-          onAccountChange={(value) => {
-            setDeliveryAccountID(value)
-            setDeliveryTargetID(selectBestTarget(data.im.targets, value))
-            setDeliveryDirty(true)
-            setDeliveryFeedback(null)
-            setDeliveryError(null)
-          }}
-          onEnabledChange={(value) => {
-            setDeliveryEnabled(value)
-            setDeliveryDirty(true)
-            setDeliveryFeedback(null)
-            setDeliveryError(null)
-          }}
-          onSave={() => void saveDeliverySettings()}
-          onTargetChange={(value) => {
-            setDeliveryTargetID(value)
-            setDeliveryDirty(true)
-            setDeliveryFeedback(null)
-            setDeliveryError(null)
-          }}
-        />
+          <div className="settings-nav-list">
+            {settingsSections.map((section) => (
+              <button
+                key={section.key}
+                className={`settings-nav-item ${section.key === activeSection ? 'settings-nav-item-active' : ''}`}
+                onClick={() => setActiveSection(section.key)}
+                type="button"
+              >
+                <span>{section.eyebrow}</span>
+                <strong>{section.title}</strong>
+                <p>{section.description}</p>
+              </button>
+            ))}
+          </div>
+        </aside>
 
-        <WeChatLoginPanel
-          error={loginPanel.error}
-          expiresAt={loginPanel.expiresAt}
-          loading={loginPanel.loading}
-          message={loginPanel.message}
-          polling={loginPanel.polling}
-          qrDataUrl={loginPanel.qrDataUrl}
-          qrRawText={loginPanel.qrRawText}
-          onStart={() => void startWeChatLogin()}
-        />
+        <div className="settings-stage">
+          <section className="panel settings-stage-card">
+            <div className="panel-head compact">
+              <div>
+                <p className="eyebrow">{currentSection.eyebrow}</p>
+                <h3>{currentSection.title}</h3>
+              </div>
+            </div>
+            <p className="settings-stage-copy">{currentSection.description}</p>
+          </section>
 
-        <WeChatAccountsPanel
-          accounts={data.im.accounts}
-          onDeleteAccount={(accountID) => void deleteAccount(accountID)}
-        />
+          {activeSection === 'system' ? (
+            <section className="settings-grid-page settings-grid-single">
+              <SessionSettingsPanel
+                settingsError={settingsError}
+                settingsFeedback={settingsFeedback}
+                settingsSaving={settingsSaving}
+                windowDirty={windowDirty}
+                windowInput={windowInput}
+                onSave={() => void saveSessionWindowSettings()}
+                onWindowInputChange={(value) => {
+                  setWindowInput(value)
+                  setWindowDirty(true)
+                  setSettingsFeedback(null)
+                  setSettingsError(null)
+                }}
+              />
+            </section>
+          ) : (
+            <section className="settings-grid-page">
+              <IMDeliveryPanel
+                accountID={deliveryAccountID}
+                accounts={data.im.accounts}
+                dirty={deliveryDirty}
+                enabled={deliveryEnabled}
+                error={deliveryError}
+                feedback={deliveryFeedback}
+                saving={deliverySaving}
+                targetID={deliveryTargetID}
+                targets={deliveryTargets}
+                onAccountChange={(value) => {
+                  setDeliveryAccountID(value)
+                  setDeliveryTargetID(selectBestTarget(data.im.targets, value))
+                  setDeliveryDirty(true)
+                  setDeliveryFeedback(null)
+                  setDeliveryError(null)
+                }}
+                onEnabledChange={(value) => {
+                  setDeliveryEnabled(value)
+                  setDeliveryDirty(true)
+                  setDeliveryFeedback(null)
+                  setDeliveryError(null)
+                }}
+                onSave={() => void saveDeliverySettings()}
+                onTargetChange={(value) => {
+                  setDeliveryTargetID(value)
+                  setDeliveryDirty(true)
+                  setDeliveryFeedback(null)
+                  setDeliveryError(null)
+                }}
+              />
 
-        <IMTargetsPanel
-          accountID={targetAccountID}
-          accountTargets={targetFormTargets}
-          accounts={data.im.accounts}
-          error={targetError}
-          feedback={targetFeedback}
-          name={targetName}
-          saving={targetSaving}
-          setDefault={targetDefault}
-          targetUserID={targetUserID}
-          onAccountChange={(value) => {
-            setTargetAccountID(value)
-            setTargetFeedback(null)
-            setTargetError(null)
-          }}
-          onDeleteTarget={(targetID) => void deleteTarget(targetID)}
-          onNameChange={setTargetName}
-          onSave={() => void createTarget()}
-          onSetDefaultChange={setTargetDefault}
-          onSetDefaultTarget={(accountID, targetID) => void setDefaultTarget(accountID, targetID)}
-          onTargetUserIDChange={setTargetUserID}
-        />
+              <WeChatLoginPanel
+                error={loginPanel.error}
+                expiresAt={loginPanel.expiresAt}
+                loading={loginPanel.loading}
+                message={loginPanel.message}
+                polling={loginPanel.polling}
+                qrDataUrl={loginPanel.qrDataUrl}
+                qrRawText={loginPanel.qrRawText}
+                onStart={() => void startWeChatLogin()}
+              />
 
-        <IMEventsPanel events={data.im.events} />
+              <WeChatAccountsPanel
+                accounts={data.im.accounts}
+                onDeleteAccount={(accountID) => void deleteAccount(accountID)}
+              />
+
+              <IMTargetsPanel
+                accountID={targetAccountID}
+                accountTargets={targetFormTargets}
+                accounts={data.im.accounts}
+                error={targetError}
+                feedback={targetFeedback}
+                name={targetName}
+                saving={targetSaving}
+                setDefault={targetDefault}
+                targetUserID={targetUserID}
+                onAccountChange={(value) => {
+                  setTargetAccountID(value)
+                  setTargetFeedback(null)
+                  setTargetError(null)
+                }}
+                onDeleteTarget={(targetID) => void deleteTarget(targetID)}
+                onNameChange={setTargetName}
+                onSave={() => void createTarget()}
+                onSetDefaultChange={setTargetDefault}
+                onSetDefaultTarget={(accountID, targetID) => void setDefaultTarget(accountID, targetID)}
+                onTargetUserIDChange={setTargetUserID}
+              />
+
+              <IMEventsPanel events={data.im.events} />
+            </section>
+          )}
+        </div>
       </section>
     </main>
   )
 }
-

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,16 +1,16 @@
 import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react'
 import { IMDeliveryPanel } from '../components/settings/IMDeliveryPanel'
-import { IMEventsPanel } from '../components/settings/IMEventsPanel'
 import { IMTargetsPanel } from '../components/settings/IMTargetsPanel'
 import { SessionSettingsPanel } from '../components/settings/SessionSettingsPanel'
 import { WeChatAccountsPanel } from '../components/settings/WeChatAccountsPanel'
 import { WeChatLoginPanel } from '../components/settings/WeChatLoginPanel'
-import { fetchState, postJSON } from '../lib/api'
+import { postJSON } from '../lib/api'
 import { normalizeSettings, selectBestTarget } from '../lib/dashboard'
 import type {
   DashboardState,
   SessionSettings,
   SettingsSnapshot,
+  WeChatLoginCandidate,
   WeChatLoginStart,
   WeChatLoginStatus,
 } from '../types'
@@ -25,8 +25,10 @@ type SettingsSection = {
 }
 
 type LoginPanelState = {
+  open: boolean
   loading: boolean
   polling: boolean
+  confirming: boolean
   sessionKey: string | null
   qrDataUrl: string | null
   qrRawText: string | null
@@ -34,11 +36,14 @@ type LoginPanelState = {
   status: WeChatLoginStatus['status'] | null
   message: string | null
   error: string | null
+  candidate: WeChatLoginCandidate | null
 }
 
 const emptyLoginState: LoginPanelState = {
+  open: false,
   loading: false,
   polling: false,
+  confirming: false,
   sessionKey: null,
   qrDataUrl: null,
   qrRawText: null,
@@ -46,6 +51,7 @@ const emptyLoginState: LoginPanelState = {
   status: null,
   message: null,
   error: null,
+  candidate: null,
 }
 
 const settingsSections: SettingsSection[] = [
@@ -96,6 +102,23 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
   const [targetFeedback, setTargetFeedback] = useState<string | null>(null)
   const [targetError, setTargetError] = useState<string | null>(null)
 
+  const deliveryAccounts = useMemo(() => {
+    const accountIDsWithTargets = new Set(data.im.targets.map((target) => target.account_id))
+    return data.im.accounts.filter((account) => accountIDsWithTargets.has(account.id))
+  }, [data.im.accounts, data.im.targets])
+
+  const deliveryTargets = useMemo(() => {
+    return data.im.targets.filter((target) => target.account_id === deliveryAccountID)
+  }, [data.im.targets, deliveryAccountID])
+
+  const targetFormTargets = useMemo(() => {
+    return data.im.targets.filter((target) => target.account_id === targetAccountID)
+  }, [data.im.targets, targetAccountID])
+
+  const currentSection = useMemo(() => {
+    return settingsSections.find((section) => section.key === activeSection) ?? settingsSections[0]
+  }, [activeSection])
+
   useEffect(() => {
     if (windowDirty || settingsSaving) return
     setWindowInput(String(data.settings.session_window_seconds))
@@ -115,15 +138,13 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
   ])
 
   useEffect(() => {
-    if (targetAccountID) return
-    const firstAccount = data.im.accounts[0]?.id ?? ''
-    if (firstAccount) {
-      setTargetAccountID(firstAccount)
-    }
+    const accountExists = data.im.accounts.some((account) => account.id === targetAccountID)
+    if (accountExists) return
+    setTargetAccountID(data.im.accounts[0]?.id ?? '')
   }, [data.im.accounts, targetAccountID])
 
   useEffect(() => {
-    if (!loginPanel.polling || !loginPanel.sessionKey) return
+    if (!loginPanel.open || !loginPanel.polling || !loginPanel.sessionKey) return
 
     let active = true
     const timer = window.setInterval(async () => {
@@ -142,21 +163,11 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
           ...current,
           status: payload.status?.status ?? current.status,
           message: payload.status?.message ?? current.message,
+          candidate: payload.status?.candidate ?? current.candidate,
           error: null,
           polling: nextStatus === 'pending' || nextStatus === 'scanned',
-          sessionKey:
-            nextStatus === 'pending' || nextStatus === 'scanned'
-              ? current.sessionKey
-              : null,
+          sessionKey: nextStatus === 'expired' || nextStatus === 'failed' ? null : current.sessionKey,
         }))
-
-        if (nextStatus === 'confirmed') {
-          const next = await fetchState()
-          if (!active) return
-          setData(next)
-          setDeliveryFeedback('微信账号已登录，现在可以选择它作为 IM 文本触达渠道。')
-          setDeliveryError(null)
-        }
       } catch (err) {
         if (!active) return
         setLoginPanel((current) => ({
@@ -171,19 +182,7 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
       active = false
       window.clearInterval(timer)
     }
-  }, [loginPanel.polling, loginPanel.sessionKey, setData])
-
-  const deliveryTargets = useMemo(() => {
-    return data.im.targets.filter((target) => target.account_id === deliveryAccountID)
-  }, [data.im.targets, deliveryAccountID])
-
-  const targetFormTargets = useMemo(() => {
-    return data.im.targets.filter((target) => target.account_id === targetAccountID)
-  }, [data.im.targets, targetAccountID])
-
-  const currentSection = useMemo(() => {
-    return settingsSections.find((section) => section.key === activeSection) ?? settingsSections[0]
-  }, [activeSection])
+  }, [loginPanel.open, loginPanel.polling, loginPanel.sessionKey])
 
   async function saveSessionWindowSettings() {
     const nextValue = Number(windowInput)
@@ -220,6 +219,12 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
   }
 
   async function saveDeliverySettings() {
+    if (deliveryEnabled && (!deliveryAccountID || !deliveryTargetID)) {
+      setDeliveryError('开启镜像前，请先选择一个已经配置好的账号和触达目标。')
+      setDeliveryFeedback(null)
+      return
+    }
+
     setDeliverySaving(true)
     setDeliveryError(null)
     setDeliveryFeedback(null)
@@ -247,7 +252,9 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
   async function startWeChatLogin() {
     setLoginPanel({
       ...emptyLoginState,
+      open: true,
       loading: true,
+      message: '正在准备微信登录二维码。',
     })
     try {
       const payload = await postJSON<{ login?: WeChatLoginStart }>('/api/im/wechat/login/start', {})
@@ -255,8 +262,10 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
         throw new Error('登录二维码返回为空')
       }
       setLoginPanel({
+        open: true,
         loading: false,
         polling: true,
+        confirming: false,
         sessionKey: payload.login.session_key,
         qrDataUrl: payload.login.qr_code_data_url,
         qrRawText: payload.login.qr_raw_text,
@@ -264,12 +273,49 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
         status: 'pending',
         message: '请使用微信扫描下方二维码。',
         error: null,
+        candidate: null,
       })
     } catch (err) {
       setLoginPanel({
         ...emptyLoginState,
+        open: true,
         error: err instanceof Error ? err.message : '启动微信登录失败',
       })
+    }
+  }
+
+  function closeWeChatLogin() {
+    setLoginPanel(emptyLoginState)
+  }
+
+  async function confirmWeChatLogin() {
+    if (!loginPanel.sessionKey) {
+      setLoginPanel((current) => ({
+        ...current,
+        error: '当前登录会话已经失效，请重新扫码。',
+      }))
+      return
+    }
+
+    setLoginPanel((current) => ({
+      ...current,
+      confirming: true,
+      error: null,
+    }))
+    try {
+      await postJSON('/api/im/wechat/login/confirm', {
+        session_key: loginPanel.sessionKey,
+      })
+      await refresh()
+      setLoginPanel(emptyLoginState)
+      setDeliveryFeedback('微信账号已添加，你现在可以继续配置触达目标和镜像规则。')
+      setDeliveryError(null)
+    } catch (err) {
+      setLoginPanel((current) => ({
+        ...current,
+        confirming: false,
+        error: err instanceof Error ? err.message : '确认添加微信账号失败',
+      }))
     }
   }
 
@@ -427,7 +473,7 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
             <section className="settings-grid-page">
               <IMDeliveryPanel
                 accountID={deliveryAccountID}
-                accounts={data.im.accounts}
+                accounts={deliveryAccounts}
                 dirty={deliveryDirty}
                 enabled={deliveryEnabled}
                 error={deliveryError}
@@ -457,20 +503,11 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
                 }}
               />
 
-              <WeChatLoginPanel
-                error={loginPanel.error}
-                expiresAt={loginPanel.expiresAt}
-                loading={loginPanel.loading}
-                message={loginPanel.message}
-                polling={loginPanel.polling}
-                qrDataUrl={loginPanel.qrDataUrl}
-                qrRawText={loginPanel.qrRawText}
-                onStart={() => void startWeChatLogin()}
-              />
-
               <WeChatAccountsPanel
                 accounts={data.im.accounts}
+                loginBusy={loginPanel.open}
                 onDeleteAccount={(accountID) => void deleteAccount(accountID)}
+                onStartLogin={() => void startWeChatLogin()}
               />
 
               <IMTargetsPanel
@@ -495,12 +532,26 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
                 onSetDefaultTarget={(accountID, targetID) => void setDefaultTarget(accountID, targetID)}
                 onTargetUserIDChange={setTargetUserID}
               />
-
-              <IMEventsPanel events={data.im.events} />
             </section>
           )}
         </div>
       </section>
+
+      <WeChatLoginPanel
+        candidate={loginPanel.candidate}
+        confirming={loginPanel.confirming}
+        error={loginPanel.error}
+        expiresAt={loginPanel.expiresAt}
+        loading={loginPanel.loading}
+        message={loginPanel.message}
+        open={loginPanel.open}
+        polling={loginPanel.polling}
+        qrDataUrl={loginPanel.qrDataUrl}
+        qrRawText={loginPanel.qrRawText}
+        status={loginPanel.status}
+        onClose={() => closeWeChatLogin()}
+        onConfirm={() => void confirmWeChatLogin()}
+      />
     </main>
   )
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -691,10 +691,102 @@ code {
   gap: 14px;
 }
 
+.settings-workspace {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+  gap: 20px;
+  align-items: start;
+}
+
+.settings-nav-card,
+.settings-stage-card {
+  min-height: auto;
+}
+
+.settings-nav-card {
+  position: sticky;
+  top: 24px;
+}
+
+.settings-nav-list {
+  display: grid;
+  gap: 12px;
+}
+
+.settings-nav-item {
+  width: 100%;
+  text-align: left;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 22px;
+  padding: 18px;
+  color: rgba(237, 242, 255, 0.84);
+  background: linear-gradient(160deg, rgba(18, 31, 54, 0.88), rgba(11, 17, 31, 0.74));
+  font: inherit;
+  cursor: pointer;
+  transition:
+    transform 180ms ease,
+    border-color 180ms ease,
+    background 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.settings-nav-item:hover {
+  transform: translateY(-1px);
+  border-color: rgba(42, 234, 196, 0.24);
+}
+
+.settings-nav-item span {
+  display: block;
+  margin-bottom: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.72rem;
+  color: rgba(237, 242, 255, 0.46);
+}
+
+.settings-nav-item strong {
+  display: block;
+  font-size: 1.08rem;
+  letter-spacing: -0.02em;
+}
+
+.settings-nav-item p {
+  margin: 8px 0 0;
+  color: rgba(237, 242, 255, 0.68);
+  line-height: 1.6;
+}
+
+.settings-nav-item-active {
+  border-color: rgba(42, 234, 196, 0.32);
+  background:
+    linear-gradient(160deg, rgba(16, 47, 51, 0.92), rgba(11, 17, 31, 0.82)),
+    linear-gradient(135deg, rgba(42, 234, 196, 0.18), rgba(255, 192, 98, 0.12));
+  box-shadow: inset 0 1px 0 rgba(92, 251, 236, 0.22), 0 18px 60px rgba(0, 0, 0, 0.32);
+}
+
+.settings-nav-item-active span {
+  color: rgba(184, 255, 224, 0.78);
+}
+
+.settings-stage {
+  display: grid;
+  gap: 18px;
+}
+
+.settings-stage-copy {
+  margin: 0;
+  color: rgba(237, 242, 255, 0.72);
+  line-height: 1.7;
+}
+
 .settings-grid-page {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 20px;
+}
+
+.settings-grid-single {
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .settings-panel {
@@ -811,11 +903,16 @@ code {
 @media (max-width: 1100px) {
   .hero,
   .content-grid,
+  .settings-workspace,
   .settings-grid-page,
   .settings-hero-card,
   .target-editor,
   .settings-login-grid {
     grid-template-columns: 1fr;
+  }
+
+  .settings-nav-card {
+    position: static;
   }
 
   .metrics-grid {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -797,9 +797,38 @@ code {
   grid-column: 1 / -1;
 }
 
+.settings-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(2, 6, 15, 0.72);
+  backdrop-filter: blur(16px);
+}
+
+.settings-modal-card {
+  width: min(860px, 100%);
+  max-height: min(92vh, 920px);
+  overflow: auto;
+  padding: 24px;
+  border-radius: 28px;
+  backdrop-filter: blur(18px);
+  background: rgba(8, 13, 24, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.4);
+}
+
 .settings-login-grid {
   display: grid;
   grid-template-columns: minmax(240px, 280px) minmax(0, 1fr);
+  gap: 18px;
+}
+
+.settings-login-confirm {
+  display: grid;
   gap: 18px;
 }
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -111,8 +111,15 @@ export type WeChatLoginStart = {
   expires_at: string
 }
 
+export type WeChatLoginCandidate = {
+  remote_account_id: string
+  owner_user_id: string
+  display_name: string
+  base_url: string
+}
+
 export type WeChatLoginStatus = {
   status: 'pending' | 'scanned' | 'confirmed' | 'expired' | 'failed'
   message: string
-  account?: IMAccount
+  candidate?: WeChatLoginCandidate
 }


### PR DESCRIPTION
## 变更说明

本 PR 针对设置页的信息架构做了一次收口，不再把系统设置和 IM 配置混在同一个长滚动页面里，而是改为左侧菜单切换、右侧内容展示的结构。

主要调整：

- 设置页新增左侧配置导航
- 一级菜单拆分为：
  - 系统设置
  - IM 配置
- 右侧内容区只展示当前选中的配置域，避免所有面板一次性堆叠
- 系统设置保留独立展示空间，用于承载会话窗口等全局配置
- IM 配置单独展示微信登录、账号管理、触达目标、镜像配置和事件流
- 补充对应样式，兼顾桌面端分栏和移动端回落布局

## 价值

- 降低设置页滚动查找成本
- 明确系统设置与 IM 配置的边界
- 为后续继续增加更多设置模块预留稳定的扩展结构

## 验证

- `npm run build:web`

Closes #9
