### PR TITLE
补充默认 IM 渠道文本调试发送入口

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -440,6 +440,7 @@ Important routes:
 - `POST /api/im/wechat/login/start`
 - `GET /api/im/wechat/login/status`
 - `POST /api/im/wechat/login/confirm`
+- `POST /api/im/debug/send-default`
 - `POST /api/im/targets`
 - `POST /api/im/targets/default`
 - `POST /api/im/targets/delete`

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ flowchart TD
 - 提供独立的 React + Vite dashboard
 - 使用 MySQL 保存任务、会话和插件私有状态
 - 会话上下文默认使用滑动窗口，并支持在 Dashboard 中调整窗口秒数
-- 提供第一期独立 IM Gateway：支持微信扫码登录、确认添加账号、多账号管理、文本触达配置
+- 提供第一期独立 IM Gateway：支持微信扫码登录、确认添加账号、多账号管理、文本触达配置和默认渠道调试发送
 - 支持把小爱的正常回复异步镜像到选中的微信私聊目标，不阻塞设备侧播报
 
 当前内置工具：
@@ -254,6 +254,7 @@ Go 后端只提供 API，前端位于 `web/`。
 - `POST /api/im/wechat/login/start`
 - `GET /api/im/wechat/login/status`
 - `POST /api/im/wechat/login/confirm`
+- `POST /api/im/debug/send-default`
 - `POST /api/im/targets`
 - `POST /api/im/targets/default`
 - `POST /api/im/targets/delete`

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -30,6 +30,7 @@ type Server struct {
 		StartWeChatLogin() (im.WeChatLoginStart, error)
 		PollWeChatLogin(sessionKey string) (im.WeChatLoginStatus, error)
 		ConfirmWeChatLogin(sessionKey string) (im.Account, error)
+		SendTextToDefaultChannel(text string) (im.DeliveryReceipt, error)
 		UpsertTarget(accountID string, name string, targetUserID string, setDefault bool) (im.Target, error)
 		SetDefaultTarget(accountID string, targetID string) error
 		DeleteTarget(targetID string) error
@@ -50,6 +51,7 @@ func New(addr string, tasks *tasks.Manager, claude *complextask.Service, convers
 	StartWeChatLogin() (im.WeChatLoginStart, error)
 	PollWeChatLogin(sessionKey string) (im.WeChatLoginStatus, error)
 	ConfirmWeChatLogin(sessionKey string) (im.Account, error)
+	SendTextToDefaultChannel(text string) (im.DeliveryReceipt, error)
 	UpsertTarget(accountID string, name string, targetUserID string, setDefault bool) (im.Target, error)
 	SetDefaultTarget(accountID string, targetID string) error
 	DeleteTarget(targetID string) error
@@ -77,6 +79,7 @@ func (s *Server) ListenAndServe() error {
 	mux.HandleFunc("/api/im/wechat/login/start", s.handleWeChatLoginStart)
 	mux.HandleFunc("/api/im/wechat/login/status", s.handleWeChatLoginStatus)
 	mux.HandleFunc("/api/im/wechat/login/confirm", s.handleWeChatLoginConfirm)
+	mux.HandleFunc("/api/im/debug/send-default", s.handleIMDebugSendDefault)
 	mux.HandleFunc("/api/im/targets", s.handleIMTargets)
 	mux.HandleFunc("/api/im/targets/default", s.handleIMTargetDefault)
 	mux.HandleFunc("/api/im/targets/delete", s.handleIMTargetDelete)
@@ -272,6 +275,36 @@ func (s *Server) handleWeChatLoginConfirm(w http.ResponseWriter, r *http.Request
 	writeJSON(w, map[string]any{
 		"ok":      true,
 		"account": account,
+	})
+}
+
+func (s *Server) handleIMDebugSendDefault(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.im == nil {
+		http.Error(w, "im gateway is not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	var payload struct {
+		Text string `json:"text"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, fmt.Sprintf("decode im debug send payload: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	receipt, err := s.im.SendTextToDefaultChannel(payload.Text)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	writeJSON(w, map[string]any{
+		"ok":      true,
+		"receipt": receipt,
 	})
 }
 

--- a/internal/dashboard/server_test.go
+++ b/internal/dashboard/server_test.go
@@ -62,6 +62,8 @@ type fakeIM struct {
 	lastDeliveryCfg settings.Snapshot
 	confirmAccount  im.Account
 	confirmSession  string
+	debugText       string
+	debugReceipt    im.DeliveryReceipt
 	resetCalls      int
 }
 
@@ -90,6 +92,29 @@ func (f *fakeIM) ConfirmWeChatLogin(sessionKey string) (im.Account, error) {
 		}
 	}
 	return f.confirmAccount, nil
+}
+
+func (f *fakeIM) SendTextToDefaultChannel(text string) (im.DeliveryReceipt, error) {
+	f.debugText = text
+	if f.debugReceipt.MessageID == "" {
+		f.debugReceipt = im.DeliveryReceipt{
+			Account: im.Account{
+				ID:              "account_1",
+				Platform:        im.PlatformWeChat,
+				RemoteAccountID: "bot@im.bot",
+				DisplayName:     "bot@im.bot",
+			},
+			Target: im.Target{
+				ID:           "target_1",
+				AccountID:    "account_1",
+				Name:         "我的微信",
+				TargetUserID: "user@im.wechat",
+			},
+			MessageID: "msg_1",
+			Text:      text,
+		}
+	}
+	return f.debugReceipt, nil
 }
 
 func (f *fakeIM) UpsertTarget(accountID string, name string, targetUserID string, setDefault bool) (im.Target, error) {
@@ -290,5 +315,40 @@ func TestHandleWeChatLoginConfirmPersistsAfterExplicitConfirmation(t *testing.T)
 	}
 	if payload.Account.RemoteAccountID != "bot@im.bot" {
 		t.Fatalf("RemoteAccountID = %q, want bot@im.bot", payload.Account.RemoteAccountID)
+	}
+}
+
+func TestHandleIMDebugSendDefaultUsesPostedText(t *testing.T) {
+	t.Parallel()
+
+	imGateway := &fakeIM{}
+	server := New(":0", nil, nil, nil, &fakeSettings{snapshot: settings.Snapshot{SessionWindowSeconds: 300}}, imGateway)
+	req := httptest.NewRequest(http.MethodPost, "/api/im/debug/send-default", strings.NewReader(`{"text":"调试消息"}`))
+	recorder := httptest.NewRecorder()
+
+	server.handleIMDebugSendDefault(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if imGateway.debugText != "调试消息" {
+		t.Fatalf("debugText = %q, want 调试消息", imGateway.debugText)
+	}
+
+	var payload struct {
+		OK      bool               `json:"ok"`
+		Receipt im.DeliveryReceipt `json:"receipt"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if !payload.OK {
+		t.Fatal("OK = false, want true")
+	}
+	if payload.Receipt.MessageID != "msg_1" {
+		t.Fatalf("MessageID = %q, want msg_1", payload.Receipt.MessageID)
+	}
+	if payload.Receipt.Text != "调试消息" {
+		t.Fatalf("Text = %q, want 调试消息", payload.Receipt.Text)
 	}
 }

--- a/internal/im/model.go
+++ b/internal/im/model.go
@@ -50,6 +50,13 @@ type DeliveryConfig struct {
 	SelectedTargetID  string `json:"selected_target_id"`
 }
 
+type DeliveryReceipt struct {
+	Account   Account `json:"account"`
+	Target    Target  `json:"target"`
+	MessageID string  `json:"message_id"`
+	Text      string  `json:"text"`
+}
+
 type WeChatLoginStart struct {
 	SessionKey    string    `json:"session_key"`
 	QRRawText     string    `json:"qr_raw_text"`

--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -260,6 +260,28 @@ func (s *Service) UpdateDeliveryConfig(enabled bool, accountID string, targetID 
 	return s.settings.UpdateIMDelivery(enabled, accountID, targetID)
 }
 
+func (s *Service) SendTextToDefaultChannel(text string) (DeliveryReceipt, error) {
+	if s == nil || s.store == nil || s.settings == nil {
+		return DeliveryReceipt{}, fmt.Errorf("im service is not configured")
+	}
+
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return DeliveryReceipt{}, fmt.Errorf("debug text is required")
+	}
+
+	cfg := s.settings.Snapshot()
+	if strings.TrimSpace(cfg.IMSelectedAccountID) == "" || strings.TrimSpace(cfg.IMSelectedTargetID) == "" {
+		return DeliveryReceipt{}, fmt.Errorf("默认渠道尚未配置，请先保存账号和触达目标")
+	}
+
+	return s.deliverText(deliveryRequest{
+		AccountID: cfg.IMSelectedAccountID,
+		TargetID:  cfg.IMSelectedTargetID,
+		Text:      text,
+	})
+}
+
 func (s *Service) Reset() error {
 	if s == nil || s.store == nil {
 		return nil
@@ -309,49 +331,55 @@ func (s *Service) MirrorText(text string) {
 
 func (s *Service) runDeliveryLoop() {
 	for request := range s.deliveries {
-		if err := s.deliverText(request); err != nil {
+		if _, err := s.deliverText(request); err != nil {
 			log.Printf("im mirror delivery failed: account=%s target=%s err=%v", request.AccountID, request.TargetID, err)
 		}
 	}
 }
 
-func (s *Service) deliverText(request deliveryRequest) error {
+func (s *Service) deliverText(request deliveryRequest) (DeliveryReceipt, error) {
 	account, ok, err := s.store.GetAccount(request.AccountID)
 	if err != nil {
-		return err
+		return DeliveryReceipt{}, err
 	}
 	if !ok {
-		return fmt.Errorf("im account %q not found", request.AccountID)
+		return DeliveryReceipt{}, fmt.Errorf("im account %q not found", request.AccountID)
 	}
 
 	target, ok, err := s.store.GetTarget(request.TargetID)
 	if err != nil {
-		return err
+		return DeliveryReceipt{}, err
 	}
 	if !ok {
-		return fmt.Errorf("im target %q not found", request.TargetID)
+		return DeliveryReceipt{}, fmt.Errorf("im target %q not found", request.TargetID)
 	}
 	if target.AccountID != account.ID {
-		return fmt.Errorf("im target %q does not belong to account %q", target.ID, account.ID)
+		return DeliveryReceipt{}, fmt.Errorf("im target %q does not belong to account %q", target.ID, account.ID)
 	}
 
 	adapter, ok := s.adapters[account.Platform]
 	if !ok {
-		return fmt.Errorf("im adapter %q is not configured", account.Platform)
+		return DeliveryReceipt{}, fmt.Errorf("im adapter %q is not configured", account.Platform)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
-	if _, err := adapter.SendText(ctx, account, target, request.Text); err != nil {
+	result, err := adapter.SendText(ctx, account, target, request.Text)
+	if err != nil {
 		_ = s.store.MarkDeliveryFailure(account.ID, err.Error())
 		_ = s.store.AppendEvent(account.ID, "send_failed", fmt.Sprintf("发送到 %s 失败：%s", target.Name, err.Error()))
-		return err
+		return DeliveryReceipt{}, err
 	}
 
 	_ = s.store.MarkDeliverySuccess(account.ID)
 	_ = s.store.AppendEvent(account.ID, "send", fmt.Sprintf("已发送到 %s：%s", target.Name, trimForEvent(request.Text)))
-	return nil
+	return DeliveryReceipt{
+		Account:   account,
+		Target:    target,
+		MessageID: result.MessageID,
+		Text:      request.Text,
+	}, nil
 }
 
 func (s *Service) repairDeliveryConfigAfterMutation(accountID string, targetID string) error {

--- a/internal/im/service_test.go
+++ b/internal/im/service_test.go
@@ -156,6 +156,52 @@ func TestServiceConfirmWeChatLoginPersistsAccountAfterExplicitConfirmation(t *te
 	}
 }
 
+func TestServiceSendTextToDefaultChannelUsesSavedSelectionEvenWhenMirrorDisabled(t *testing.T) {
+	t.Parallel()
+
+	dsn := testmysql.NewDSN(t)
+	settingsStore, err := settings.NewStore(dsn)
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	service, err := NewService(dsn, settingsStore)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	adapter := &stubAdapter{}
+	service.adapters["stub"] = adapter
+
+	account, err := service.store.UpsertAccount("stub", "bot@im.bot", "user@im.wechat", "Bot", "https://example.com", "token")
+	if err != nil {
+		t.Fatalf("UpsertAccount() error = %v", err)
+	}
+	target, err := service.store.UpsertTarget(account.ID, "我的微信", "user@im.wechat", true)
+	if err != nil {
+		t.Fatalf("UpsertTarget() error = %v", err)
+	}
+	if _, err := service.UpdateDeliveryConfig(false, account.ID, target.ID); err != nil {
+		t.Fatalf("UpdateDeliveryConfig() error = %v", err)
+	}
+
+	receipt, err := service.SendTextToDefaultChannel("调试消息")
+	if err != nil {
+		t.Fatalf("SendTextToDefaultChannel() error = %v", err)
+	}
+	if receipt.Account.ID != account.ID {
+		t.Fatalf("receipt.Account.ID = %q, want %q", receipt.Account.ID, account.ID)
+	}
+	if receipt.Target.ID != target.ID {
+		t.Fatalf("receipt.Target.ID = %q, want %q", receipt.Target.ID, target.ID)
+	}
+	if receipt.Text != "调试消息" {
+		t.Fatalf("receipt.Text = %q, want 调试消息", receipt.Text)
+	}
+	if adapter.sentCount() != 1 {
+		t.Fatalf("sentCount() = %d, want 1", adapter.sentCount())
+	}
+}
+
 func TestServiceMirrorTextUpdatesDeliverySuccess(t *testing.T) {
 	t.Parallel()
 

--- a/web/src/components/settings/IMDebugSendPanel.tsx
+++ b/web/src/components/settings/IMDebugSendPanel.tsx
@@ -1,0 +1,96 @@
+import type { IMAccount, IMTarget } from '../../types'
+
+type Props = {
+  account: IMAccount | null
+  target: IMTarget | null
+  configDirty: boolean
+  text: string
+  sending: boolean
+  feedback: string | null
+  error: string | null
+  onTextChange: (value: string) => void
+  onSend: () => void
+}
+
+export function IMDebugSendPanel({
+  account,
+  target,
+  configDirty,
+  text,
+  sending,
+  feedback,
+  error,
+  onTextChange,
+  onSend,
+}: Props) {
+  const ready = Boolean(account && target)
+
+  return (
+    <article className="panel settings-panel panel-wide">
+      <div className="panel-head compact">
+        <div>
+          <p className="eyebrow">IM DEBUG</p>
+          <h3>默认渠道调试</h3>
+        </div>
+      </div>
+
+      <div className="settings-form">
+        <p className="settings-note">
+          这里始终命中当前已经保存的默认渠道，不依赖自动镜像开关。适合单独验证账号、目标和通道是否正常。
+        </p>
+
+        {ready ? (
+          <div className="focus-grid">
+            <div className="task-meta">
+              <span>当前渠道</span>
+              <p>{account?.platform || '—'}</p>
+            </div>
+            <div className="task-meta">
+              <span>当前账号</span>
+              <p>{account?.display_name || account?.remote_account_id || '—'}</p>
+            </div>
+            <div className="task-meta task-meta-wide">
+              <span>当前目标</span>
+              <p>{target?.name} · {target?.target_user_id}</p>
+            </div>
+          </div>
+        ) : (
+          <div className="empty-card">请先在上方保存一个默认微信账号和触达目标，然后再发送测试消息。</div>
+        )}
+
+        {configDirty ? (
+          <div className="settings-feedback">
+            上方镜像配置还有未保存的修改；调试发送仍然会命中当前已保存的默认渠道。
+          </div>
+        ) : null}
+
+        <label className="settings-field">
+          <span>测试文本</span>
+          <textarea
+            className="settings-textarea"
+            disabled={!ready || sending}
+            placeholder="例如：这是一条默认渠道调试消息。"
+            rows={4}
+            value={text}
+            onChange={(event) => onTextChange(event.target.value)}
+          />
+        </label>
+
+        <div className="settings-actions">
+          <button
+            className="settings-button"
+            disabled={!ready || sending || !text.trim()}
+            onClick={() => onSend()}
+            type="button"
+          >
+            {sending ? '发送中...' : '发送测试消息'}
+          </button>
+          <span className="settings-note">当前阶段只支持文本消息。</span>
+        </div>
+
+        {feedback ? <div className="settings-feedback">{feedback}</div> : null}
+        {error ? <div className="error-banner settings-error">{error}</div> : null}
+      </div>
+    </article>
+  )
+}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react'
+import { IMDebugSendPanel } from '../components/settings/IMDebugSendPanel'
 import { IMDeliveryPanel } from '../components/settings/IMDeliveryPanel'
 import { IMTargetsPanel } from '../components/settings/IMTargetsPanel'
 import { SessionSettingsPanel } from '../components/settings/SessionSettingsPanel'
@@ -8,6 +9,7 @@ import { postJSON } from '../lib/api'
 import { normalizeSettings, selectBestTarget } from '../lib/dashboard'
 import type {
   DashboardState,
+  IMDeliveryReceipt,
   SessionSettings,
   SettingsSnapshot,
   WeChatLoginCandidate,
@@ -91,6 +93,10 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
   const [deliverySaving, setDeliverySaving] = useState(false)
   const [deliveryFeedback, setDeliveryFeedback] = useState<string | null>(null)
   const [deliveryError, setDeliveryError] = useState<string | null>(null)
+  const [debugText, setDebugText] = useState('')
+  const [debugSending, setDebugSending] = useState(false)
+  const [debugFeedback, setDebugFeedback] = useState<string | null>(null)
+  const [debugError, setDebugError] = useState<string | null>(null)
 
   const [loginPanel, setLoginPanel] = useState<LoginPanelState>(emptyLoginState)
 
@@ -110,6 +116,18 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
   const deliveryTargets = useMemo(() => {
     return data.im.targets.filter((target) => target.account_id === deliveryAccountID)
   }, [data.im.targets, deliveryAccountID])
+
+  const savedDebugAccount = useMemo(() => {
+    return data.im.accounts.find((account) => account.id === data.settings.im_selected_account_id) ?? null
+  }, [data.im.accounts, data.settings.im_selected_account_id])
+
+  const savedDebugTarget = useMemo(() => {
+    const target = data.im.targets.find((item) => item.id === data.settings.im_selected_target_id) ?? null
+    if (!target || !savedDebugAccount || target.account_id !== savedDebugAccount.id) {
+      return null
+    }
+    return target
+  }, [data.im.targets, data.settings.im_selected_target_id, savedDebugAccount])
 
   const targetFormTargets = useMemo(() => {
     return data.im.targets.filter((target) => target.account_id === targetAccountID)
@@ -387,6 +405,34 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
     }
   }
 
+  async function sendDebugText() {
+    if (!debugText.trim()) {
+      setDebugError('请输入要发送的测试文本。')
+      setDebugFeedback(null)
+      return
+    }
+
+    setDebugSending(true)
+    setDebugError(null)
+    setDebugFeedback(null)
+    try {
+      const payload = await postJSON<{ receipt?: IMDeliveryReceipt }>('/api/im/debug/send-default', {
+        text: debugText,
+      })
+      await refresh()
+      setDebugText('')
+      if (payload.receipt) {
+        setDebugFeedback(`测试消息已发送到 ${payload.receipt.account.display_name || payload.receipt.account.remote_account_id} / ${payload.receipt.target.name}。`)
+      } else {
+        setDebugFeedback('测试消息发送成功。')
+      }
+    } catch (err) {
+      setDebugError(err instanceof Error ? err.message : '发送测试消息失败')
+    } finally {
+      setDebugSending(false)
+    }
+  }
+
   return (
     <main className="settings-page">
       <section className="settings-hero-card">
@@ -500,6 +546,22 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
                   setDeliveryDirty(true)
                   setDeliveryFeedback(null)
                   setDeliveryError(null)
+                }}
+              />
+
+              <IMDebugSendPanel
+                account={savedDebugAccount}
+                configDirty={deliveryDirty}
+                error={debugError}
+                feedback={debugFeedback}
+                sending={debugSending}
+                target={savedDebugTarget}
+                text={debugText}
+                onSend={() => void sendDebugText()}
+                onTextChange={(value) => {
+                  setDebugText(value)
+                  setDebugFeedback(null)
+                  setDebugError(null)
                 }}
               />
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -497,7 +497,8 @@ code {
   line-height: 1.6;
 }
 
-.settings-input {
+.settings-input,
+.settings-textarea {
   width: 100%;
   border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 16px;
@@ -507,7 +508,13 @@ code {
   font: inherit;
 }
 
-.settings-input:focus {
+.settings-textarea {
+  resize: vertical;
+  min-height: 112px;
+}
+
+.settings-input:focus,
+.settings-textarea:focus {
   outline: none;
   border-color: rgba(42, 234, 196, 0.46);
   box-shadow: 0 0 0 4px rgba(42, 234, 196, 0.08);

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -104,6 +104,13 @@ export type IMSnapshot = {
   events: IMEvent[]
 }
 
+export type IMDeliveryReceipt = {
+  account: IMAccount
+  target: IMTarget
+  message_id: string
+  text: string
+}
+
 export type WeChatLoginStart = {
   session_key: string
   qr_raw_text: string


### PR DESCRIPTION
## 变更说明

这个 PR 补上了默认 IM 渠道的文本调试发送能力，方便用户在设置页直接验证当前默认账号和触达目标是否可用，而不必等待小爱的正常回复去触发镜像。

## 本次实现

- 后端新增 `POST /api/im/debug/send-default`
- `im.Service` 新增同步发送到当前默认渠道的能力
- 设置页新增“默认渠道调试”面板
- 调试发送只依赖当前已保存的默认账号和默认 target，不依赖自动镜像开关
- 调试发送第一期只支持文本
- README 和 AGENTS 补充了新的 API 入口

## 验证

- `GOCACHE=$(pwd)/.gocache go test ./...`
- `npm run build:web`

Closes #11
