### PR TITLE
feat: 补充 IM 网关图片发送与媒体缓存配置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ web/dist/
 web/*.tsbuildinfo
 web/vite.config.js
 web/vite.config.d.ts
+.cache/im-media/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,13 +23,13 @@ Current responsibilities:
 - run `reply` generation for normal chat and tool-result summarization
 - drive local TTS playback on the device through the existing client protocol
 - maintain lightweight async tasks
-- provide phase-1 IM gateway capability for WeChat text delivery
+- provide phase-1 IM gateway capability for WeChat text delivery plus default-channel image debug send
 - expose a React dashboard over API + web frontend
 
 Current non-goals / known missing pieces:
 
 - no IM inbound conversation handling yet
-- no media delivery in IM gateway yet
+- no automatic IM media mirror yet beyond text
 - no group routing in IM gateway yet
 - no proper voice interruption detection
 - some latency optimizations were intentionally not carried over from earlier experiments
@@ -151,6 +151,7 @@ Config domains currently used:
 - `intent.model / base_url / api_key`
 - `reply.model / base_url / api_key`
 - `amap.api_key`
+- `im.media_cache_dir`
 
 Important:
 
@@ -200,7 +201,14 @@ IM gateway store:
   - logged-in IM accounts
   - default text delivery targets
   - recent IM gateway events
-- current scope is outbound text delivery only
+- current scope is text delivery plus default-channel image debug send
+
+Media cache:
+
+- uploaded IM debug images are cached on local disk before adapter delivery
+- cache directory comes from `config.yaml` field `im.media_cache_dir`
+- current default is `.cache/im-media` under the repo root
+- files are intentionally not auto-cleaned yet
 
 Claude-private store:
 
@@ -441,6 +449,7 @@ Important routes:
 - `GET /api/im/wechat/login/status`
 - `POST /api/im/wechat/login/confirm`
 - `POST /api/im/debug/send-default`
+- `POST /api/im/debug/send-image-default`
 - `POST /api/im/targets`
 - `POST /api/im/targets/default`
 - `POST /api/im/targets/delete`

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ flowchart TD
 - 提供独立的 React + Vite dashboard
 - 使用 MySQL 保存任务、会话和插件私有状态
 - 会话上下文默认使用滑动窗口，并支持在 Dashboard 中调整窗口秒数
-- 提供第一期独立 IM Gateway：支持微信扫码登录、确认添加账号、多账号管理、文本触达配置和默认渠道调试发送
+- 提供第一期独立 IM Gateway：支持微信扫码登录、确认添加账号、多账号管理、文本触达配置，以及默认渠道的文本 / 图片调试发送
 - 支持把小爱的正常回复异步镜像到选中的微信私聊目标，不阻塞设备侧播报
 
 当前内置工具：
@@ -145,11 +145,15 @@ reply:
   model: qwen-turbo
   base_url: https://dashscope.aliyuncs.com/compatible-mode/v1
   api_key: sk-reply-placeholder
+
+im:
+  media_cache_dir: .cache/im-media
 ```
 
 `SOUL.md` 会在启动时一并读取，用于定义主回复的人设。`config.yaml` 已被忽略，不要提交真实密钥。
 
 `database.dsn` 是当前唯一的数据库配置入口，启动时会直接从 `config.yaml` 读取。
+`im.media_cache_dir` 用于缓存上传到 IM 网关的图片文件；默认值是仓库根目录下的 `.cache/im-media`，当前不会自动清理。
 
 3. 启动本地 MySQL：
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,6 +1,9 @@
 database:
   dsn: root:root@tcp(127.0.0.1:3306)/open_xiaoai_agent
 
+im:
+  media_cache_dir: .cache/im-media
+
 openai:
   base_url: https://api.openai.com/v1
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,9 @@ type FileConfig struct {
 	Database struct {
 		DSN string `yaml:"dsn"`
 	} `yaml:"database"`
+	IM struct {
+		MediaCacheDir string `yaml:"media_cache_dir"`
+	} `yaml:"im"`
 	OpenAI struct {
 		BaseURL string `yaml:"base_url"`
 	} `yaml:"openai"`
@@ -57,18 +60,29 @@ func Load(rootDir string) (*AppConfig, error) {
 	if cfg.Soul == "" {
 		return nil, fmt.Errorf("SOUL.md is empty")
 	}
-	if err := cfg.normalize(); err != nil {
+	if err := cfg.normalize(rootDir); err != nil {
 		return nil, err
 	}
 
 	return &cfg, nil
 }
 
-func (c *AppConfig) normalize() error {
+func (c *AppConfig) normalize(rootDir string) error {
 	c.Database.DSN = strings.TrimSpace(c.Database.DSN)
 	if c.Database.DSN == "" {
 		return fmt.Errorf("database.dsn is required")
 	}
+	c.IM.MediaCacheDir = strings.TrimSpace(c.IM.MediaCacheDir)
+	if c.IM.MediaCacheDir == "" {
+		c.IM.MediaCacheDir = filepath.Join(rootDir, ".cache", "im-media")
+	} else if !filepath.IsAbs(c.IM.MediaCacheDir) {
+		c.IM.MediaCacheDir = filepath.Join(rootDir, c.IM.MediaCacheDir)
+	}
+	absMediaCacheDir, err := filepath.Abs(c.IM.MediaCacheDir)
+	if err != nil {
+		return fmt.Errorf("resolve im.media_cache_dir: %w", err)
+	}
+	c.IM.MediaCacheDir = absMediaCacheDir
 	defaultBaseURL := strings.TrimRight(strings.TrimSpace(c.OpenAI.BaseURL), "/")
 	if defaultBaseURL == "" {
 		defaultBaseURL = "https://api.openai.com/v1"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -42,6 +42,9 @@ reply:
 	if cfg.Database.DSN != "user:pass@tcp(127.0.0.1:3306)/open_xiaoai_agent" {
 		t.Fatalf("database.dsn = %q", cfg.Database.DSN)
 	}
+	if cfg.IM.MediaCacheDir != filepath.Join(dir, ".cache", "im-media") {
+		t.Fatalf("im.media_cache_dir = %q", cfg.IM.MediaCacheDir)
+	}
 	if cfg.AMap.APIKey != "amap-key" {
 		t.Fatalf("amap.api_key = %q", cfg.AMap.APIKey)
 	}
@@ -146,6 +149,35 @@ reply:
 	}
 	if cfg.Database.DSN != "user:pass@tcp(127.0.0.1:3306)/open_xiaoai_agent" {
 		t.Fatalf("database.dsn = %q", cfg.Database.DSN)
+	}
+}
+
+func TestLoad_UsesCustomMediaCacheDir(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "SOUL.md"), "# 角色\n你是一个有边界感的语音助手。")
+	writeFile(t, filepath.Join(dir, "config.yaml"), `
+database:
+  dsn: user:pass@tcp(127.0.0.1:3306)/open_xiaoai_agent
+im:
+  media_cache_dir: data/im-cache
+openai:
+  base_url: https://api.openai.com/v1
+intent:
+  model: gpt-4.1-mini
+  api_key: intent-key
+reply:
+  model: gpt-4.1
+  api_key: reply-key
+`)
+
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.IM.MediaCacheDir != filepath.Join(dir, "data", "im-cache") {
+		t.Fatalf("im.media_cache_dir = %q", cfg.IM.MediaCacheDir)
 	}
 }
 

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -3,6 +3,7 @@ package dashboard
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 
@@ -31,6 +32,7 @@ type Server struct {
 		PollWeChatLogin(sessionKey string) (im.WeChatLoginStatus, error)
 		ConfirmWeChatLogin(sessionKey string) (im.Account, error)
 		SendTextToDefaultChannel(text string) (im.DeliveryReceipt, error)
+		SendImageToDefaultChannel(req im.ImageSendRequest) (im.DeliveryReceipt, error)
 		UpsertTarget(accountID string, name string, targetUserID string, setDefault bool) (im.Target, error)
 		SetDefaultTarget(accountID string, targetID string) error
 		DeleteTarget(targetID string) error
@@ -52,6 +54,7 @@ func New(addr string, tasks *tasks.Manager, claude *complextask.Service, convers
 	PollWeChatLogin(sessionKey string) (im.WeChatLoginStatus, error)
 	ConfirmWeChatLogin(sessionKey string) (im.Account, error)
 	SendTextToDefaultChannel(text string) (im.DeliveryReceipt, error)
+	SendImageToDefaultChannel(req im.ImageSendRequest) (im.DeliveryReceipt, error)
 	UpsertTarget(accountID string, name string, targetUserID string, setDefault bool) (im.Target, error)
 	SetDefaultTarget(accountID string, targetID string) error
 	DeleteTarget(targetID string) error
@@ -80,6 +83,7 @@ func (s *Server) ListenAndServe() error {
 	mux.HandleFunc("/api/im/wechat/login/status", s.handleWeChatLoginStatus)
 	mux.HandleFunc("/api/im/wechat/login/confirm", s.handleWeChatLoginConfirm)
 	mux.HandleFunc("/api/im/debug/send-default", s.handleIMDebugSendDefault)
+	mux.HandleFunc("/api/im/debug/send-image-default", s.handleIMDebugSendImageDefault)
 	mux.HandleFunc("/api/im/targets", s.handleIMTargets)
 	mux.HandleFunc("/api/im/targets/default", s.handleIMTargetDefault)
 	mux.HandleFunc("/api/im/targets/delete", s.handleIMTargetDelete)
@@ -298,6 +302,50 @@ func (s *Server) handleIMDebugSendDefault(w http.ResponseWriter, r *http.Request
 	}
 
 	receipt, err := s.im.SendTextToDefaultChannel(payload.Text)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	writeJSON(w, map[string]any{
+		"ok":      true,
+		"receipt": receipt,
+	})
+}
+
+func (s *Server) handleIMDebugSendImageDefault(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.im == nil {
+		http.Error(w, "im gateway is not configured", http.StatusServiceUnavailable)
+		return
+	}
+	if err := r.ParseMultipartForm(16 << 20); err != nil {
+		http.Error(w, fmt.Sprintf("parse image upload form: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		http.Error(w, fmt.Sprintf("read image upload file: %v", err), http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
+
+	content, err := io.ReadAll(file)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("read image upload content: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	receipt, err := s.im.SendImageToDefaultChannel(im.ImageSendRequest{
+		FileName: header.Filename,
+		MimeType: header.Header.Get("Content-Type"),
+		Content:  content,
+		Caption:  r.FormValue("caption"),
+	})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/internal/dashboard/server_test.go
+++ b/internal/dashboard/server_test.go
@@ -1,8 +1,10 @@
 package dashboard
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -63,6 +65,7 @@ type fakeIM struct {
 	confirmAccount  im.Account
 	confirmSession  string
 	debugText       string
+	debugImage      im.ImageSendRequest
 	debugReceipt    im.DeliveryReceipt
 	resetCalls      int
 }
@@ -115,6 +118,29 @@ func (f *fakeIM) SendTextToDefaultChannel(text string) (im.DeliveryReceipt, erro
 		}
 	}
 	return f.debugReceipt, nil
+}
+
+func (f *fakeIM) SendImageToDefaultChannel(req im.ImageSendRequest) (im.DeliveryReceipt, error) {
+	f.debugImage = req
+	return im.DeliveryReceipt{
+		Account: im.Account{
+			ID:              "account_1",
+			Platform:        im.PlatformWeChat,
+			RemoteAccountID: "bot@im.bot",
+			DisplayName:     "bot@im.bot",
+		},
+		Target: im.Target{
+			ID:           "target_1",
+			AccountID:    "account_1",
+			Name:         "我的微信",
+			TargetUserID: "user@im.wechat",
+		},
+		MessageID:     "img_1",
+		Kind:          im.DeliveryKindImage,
+		Caption:       req.Caption,
+		MediaFileName: req.FileName,
+		MediaMimeType: req.MimeType,
+	}, nil
 }
 
 func (f *fakeIM) UpsertTarget(accountID string, name string, targetUserID string, setDefault bool) (im.Target, error) {
@@ -350,5 +376,64 @@ func TestHandleIMDebugSendDefaultUsesPostedText(t *testing.T) {
 	}
 	if payload.Receipt.Text != "调试消息" {
 		t.Fatalf("Text = %q, want 调试消息", payload.Receipt.Text)
+	}
+}
+
+func TestHandleIMDebugSendImageDefaultUsesUploadedFile(t *testing.T) {
+	t.Parallel()
+
+	imGateway := &fakeIM{}
+	server := New(":0", nil, nil, nil, &fakeSettings{snapshot: settings.Snapshot{SessionWindowSeconds: 300}}, imGateway)
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	fileWriter, err := writer.CreateFormFile("file", "rabbit.png")
+	if err != nil {
+		t.Fatalf("CreateFormFile() error = %v", err)
+	}
+	if _, err := fileWriter.Write([]byte("png-data")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if err := writer.WriteField("caption", "测试图片"); err != nil {
+		t.Fatalf("WriteField() error = %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/im/debug/send-image-default", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	recorder := httptest.NewRecorder()
+
+	server.handleIMDebugSendImageDefault(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if imGateway.debugImage.FileName != "rabbit.png" {
+		t.Fatalf("FileName = %q, want rabbit.png", imGateway.debugImage.FileName)
+	}
+	if string(imGateway.debugImage.Content) != "png-data" {
+		t.Fatalf("Content = %q, want png-data", string(imGateway.debugImage.Content))
+	}
+	if imGateway.debugImage.Caption != "测试图片" {
+		t.Fatalf("Caption = %q, want 测试图片", imGateway.debugImage.Caption)
+	}
+
+	var payload struct {
+		OK      bool               `json:"ok"`
+		Receipt im.DeliveryReceipt `json:"receipt"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if !payload.OK {
+		t.Fatal("OK = false, want true")
+	}
+	if payload.Receipt.Kind != im.DeliveryKindImage {
+		t.Fatalf("Kind = %q, want %q", payload.Receipt.Kind, im.DeliveryKindImage)
+	}
+	if payload.Receipt.MediaFileName != "rabbit.png" {
+		t.Fatalf("MediaFileName = %q, want rabbit.png", payload.Receipt.MediaFileName)
 	}
 }

--- a/internal/im/adapter.go
+++ b/internal/im/adapter.go
@@ -20,4 +20,5 @@ type Adapter interface {
 	StartLogin(ctx context.Context) (WeChatLoginStart, error)
 	PollLogin(ctx context.Context, sessionKey string) (WeChatLoginResult, error)
 	SendText(ctx context.Context, account Account, target Target, text string) (TextSendResult, error)
+	SendImage(ctx context.Context, account Account, target Target, image PreparedImage, caption string) (ImageSendResult, error)
 }

--- a/internal/im/media_cache.go
+++ b/internal/im/media_cache.go
@@ -1,0 +1,127 @@
+package im
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type MediaCache struct {
+	dir string
+}
+
+func NewMediaCache(dir string) (*MediaCache, error) {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return nil, fmt.Errorf("media cache dir is required")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("create media cache dir: %w", err)
+	}
+	return &MediaCache{dir: dir}, nil
+}
+
+func (c *MediaCache) Dir() string {
+	if c == nil {
+		return ""
+	}
+	return c.dir
+}
+
+func (c *MediaCache) StoreImage(req ImageSendRequest) (PreparedImage, error) {
+	if c == nil {
+		return PreparedImage{}, fmt.Errorf("media cache is not configured")
+	}
+
+	content := req.Content
+	if len(content) == 0 {
+		return PreparedImage{}, fmt.Errorf("image content is required")
+	}
+
+	fileName := filepath.Base(strings.TrimSpace(req.FileName))
+	if fileName == "." || fileName == string(filepath.Separator) {
+		fileName = ""
+	}
+	mimeType := strings.TrimSpace(req.MimeType)
+	if mimeType == "" {
+		mimeType = http.DetectContentType(content)
+	}
+	if !strings.HasPrefix(strings.ToLower(mimeType), "image/") {
+		return PreparedImage{}, fmt.Errorf("only image uploads are supported, got %q", mimeType)
+	}
+
+	ext := strings.TrimSpace(filepath.Ext(fileName))
+	if ext == "" {
+		if exts, _ := mime.ExtensionsByType(mimeType); len(exts) > 0 {
+			ext = exts[0]
+		}
+	}
+	if ext == "" {
+		ext = ".img"
+	}
+
+	prefix := sanitizeMediaBaseName(strings.TrimSuffix(fileName, filepath.Ext(fileName)))
+	if prefix == "" {
+		prefix = "weixin-image"
+	}
+	token, err := randomMediaToken(8)
+	if err != nil {
+		return PreparedImage{}, err
+	}
+	storedName := fmt.Sprintf("%s-%s%s", prefix, token, ext)
+	filePath := filepath.Join(c.dir, storedName)
+	if err := os.WriteFile(filePath, content, 0o644); err != nil {
+		return PreparedImage{}, fmt.Errorf("write cached image: %w", err)
+	}
+
+	return PreparedImage{
+		FilePath: filePath,
+		FileName: chooseMediaFileName(fileName, storedName),
+		MimeType: mimeType,
+		Size:     int64(len(content)),
+	}, nil
+}
+
+func chooseMediaFileName(original string, fallback string) string {
+	original = strings.TrimSpace(original)
+	if original != "" {
+		return original
+	}
+	return fallback
+}
+
+func sanitizeMediaBaseName(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	var b strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-' || r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+func randomMediaToken(bytesLen int) (string, error) {
+	raw := make([]byte, bytesLen)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("generate media token: %w", err)
+	}
+	return hex.EncodeToString(raw), nil
+}

--- a/internal/im/model.go
+++ b/internal/im/model.go
@@ -3,7 +3,9 @@ package im
 import "time"
 
 const (
-	PlatformWeChat = "weixin"
+	PlatformWeChat    = "weixin"
+	DeliveryKindText  = "text"
+	DeliveryKindImage = "image"
 )
 
 type Account struct {
@@ -51,10 +53,32 @@ type DeliveryConfig struct {
 }
 
 type DeliveryReceipt struct {
-	Account   Account `json:"account"`
-	Target    Target  `json:"target"`
-	MessageID string  `json:"message_id"`
-	Text      string  `json:"text"`
+	Account       Account `json:"account"`
+	Target        Target  `json:"target"`
+	MessageID     string  `json:"message_id"`
+	Kind          string  `json:"kind"`
+	Text          string  `json:"text,omitempty"`
+	Caption       string  `json:"caption,omitempty"`
+	MediaFileName string  `json:"media_file_name,omitempty"`
+	MediaMimeType string  `json:"media_mime_type,omitempty"`
+}
+
+type PreparedImage struct {
+	FilePath string
+	FileName string
+	MimeType string
+	Size     int64
+}
+
+type ImageSendRequest struct {
+	FileName string
+	MimeType string
+	Content  []byte
+	Caption  string
+}
+
+type ImageSendResult struct {
+	MessageID string
 }
 
 type WeChatLoginStart struct {

--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -17,9 +17,10 @@ type runtimeSettings interface {
 }
 
 type Service struct {
-	store    *Store
-	settings runtimeSettings
-	adapters map[string]Adapter
+	store      *Store
+	settings   runtimeSettings
+	mediaCache *MediaCache
+	adapters   map[string]Adapter
 
 	pendingMu     sync.Mutex
 	pendingLogins map[string]pendingWeChatLogin
@@ -37,15 +38,20 @@ type pendingWeChatLogin struct {
 	ConfirmedAt time.Time
 }
 
-func NewService(dsn string, runtimeSettings runtimeSettings) (*Service, error) {
+func NewService(dsn string, runtimeSettings runtimeSettings, mediaCacheDir string) (*Service, error) {
 	store, err := NewStore(dsn)
+	if err != nil {
+		return nil, err
+	}
+	mediaCache, err := NewMediaCache(mediaCacheDir)
 	if err != nil {
 		return nil, err
 	}
 
 	svc := &Service{
-		store:    store,
-		settings: runtimeSettings,
+		store:      store,
+		settings:   runtimeSettings,
+		mediaCache: mediaCache,
 		adapters: map[string]Adapter{
 			PlatformWeChat: NewWeChatAdapter(),
 		},
@@ -282,6 +288,23 @@ func (s *Service) SendTextToDefaultChannel(text string) (DeliveryReceipt, error)
 	})
 }
 
+func (s *Service) SendImageToDefaultChannel(req ImageSendRequest) (DeliveryReceipt, error) {
+	if s == nil || s.store == nil || s.settings == nil || s.mediaCache == nil {
+		return DeliveryReceipt{}, fmt.Errorf("im service is not configured")
+	}
+
+	cfg := s.settings.Snapshot()
+	if strings.TrimSpace(cfg.IMSelectedAccountID) == "" || strings.TrimSpace(cfg.IMSelectedTargetID) == "" {
+		return DeliveryReceipt{}, fmt.Errorf("默认渠道尚未配置，请先保存账号和触达目标")
+	}
+
+	prepared, err := s.mediaCache.StoreImage(req)
+	if err != nil {
+		return DeliveryReceipt{}, err
+	}
+	return s.deliverImage(cfg.IMSelectedAccountID, cfg.IMSelectedTargetID, prepared, req.Caption)
+}
+
 func (s *Service) Reset() error {
 	if s == nil || s.store == nil {
 		return nil
@@ -338,28 +361,9 @@ func (s *Service) runDeliveryLoop() {
 }
 
 func (s *Service) deliverText(request deliveryRequest) (DeliveryReceipt, error) {
-	account, ok, err := s.store.GetAccount(request.AccountID)
+	account, target, adapter, err := s.resolveDelivery(request.AccountID, request.TargetID)
 	if err != nil {
 		return DeliveryReceipt{}, err
-	}
-	if !ok {
-		return DeliveryReceipt{}, fmt.Errorf("im account %q not found", request.AccountID)
-	}
-
-	target, ok, err := s.store.GetTarget(request.TargetID)
-	if err != nil {
-		return DeliveryReceipt{}, err
-	}
-	if !ok {
-		return DeliveryReceipt{}, fmt.Errorf("im target %q not found", request.TargetID)
-	}
-	if target.AccountID != account.ID {
-		return DeliveryReceipt{}, fmt.Errorf("im target %q does not belong to account %q", target.ID, account.ID)
-	}
-
-	adapter, ok := s.adapters[account.Platform]
-	if !ok {
-		return DeliveryReceipt{}, fmt.Errorf("im adapter %q is not configured", account.Platform)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
@@ -378,8 +382,69 @@ func (s *Service) deliverText(request deliveryRequest) (DeliveryReceipt, error) 
 		Account:   account,
 		Target:    target,
 		MessageID: result.MessageID,
+		Kind:      DeliveryKindText,
 		Text:      request.Text,
 	}, nil
+}
+
+func (s *Service) deliverImage(accountID string, targetID string, image PreparedImage, caption string) (DeliveryReceipt, error) {
+	account, target, adapter, err := s.resolveDelivery(accountID, targetID)
+	if err != nil {
+		return DeliveryReceipt{}, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	result, err := adapter.SendImage(ctx, account, target, image, caption)
+	if err != nil {
+		_ = s.store.MarkDeliveryFailure(account.ID, err.Error())
+		_ = s.store.AppendEvent(account.ID, "send_failed", fmt.Sprintf("发送图片到 %s 失败：%s", target.Name, err.Error()))
+		return DeliveryReceipt{}, err
+	}
+
+	_ = s.store.MarkDeliverySuccess(account.ID)
+	eventLabel := strings.TrimSpace(caption)
+	if eventLabel == "" {
+		eventLabel = image.FileName
+	}
+	_ = s.store.AppendEvent(account.ID, "send_image", fmt.Sprintf("已发送图片到 %s：%s", target.Name, trimForEvent(eventLabel)))
+	return DeliveryReceipt{
+		Account:       account,
+		Target:        target,
+		MessageID:     result.MessageID,
+		Kind:          DeliveryKindImage,
+		Caption:       strings.TrimSpace(caption),
+		MediaFileName: image.FileName,
+		MediaMimeType: image.MimeType,
+	}, nil
+}
+
+func (s *Service) resolveDelivery(accountID string, targetID string) (Account, Target, Adapter, error) {
+	account, ok, err := s.store.GetAccount(accountID)
+	if err != nil {
+		return Account{}, Target{}, nil, err
+	}
+	if !ok {
+		return Account{}, Target{}, nil, fmt.Errorf("im account %q not found", accountID)
+	}
+
+	target, ok, err := s.store.GetTarget(targetID)
+	if err != nil {
+		return Account{}, Target{}, nil, err
+	}
+	if !ok {
+		return Account{}, Target{}, nil, fmt.Errorf("im target %q not found", targetID)
+	}
+	if target.AccountID != account.ID {
+		return Account{}, Target{}, nil, fmt.Errorf("im target %q does not belong to account %q", target.ID, account.ID)
+	}
+
+	adapter, ok := s.adapters[account.Platform]
+	if !ok {
+		return Account{}, Target{}, nil, fmt.Errorf("im adapter %q is not configured", account.Platform)
+	}
+	return account, target, adapter, nil
 }
 
 func (s *Service) repairDeliveryConfigAfterMutation(accountID string, targetID string) error {

--- a/internal/im/service_test.go
+++ b/internal/im/service_test.go
@@ -17,6 +17,8 @@ type stubAdapter struct {
 	loginErr    error
 	loginResult WeChatLoginResult
 	messages    []string
+	images      []PreparedImage
+	captions    []string
 }
 
 func (s *stubAdapter) Platform() string {
@@ -44,24 +46,48 @@ func (s *stubAdapter) SendText(ctx context.Context, account Account, target Targ
 	return TextSendResult{MessageID: "msg_1"}, nil
 }
 
+func (s *stubAdapter) SendImage(ctx context.Context, account Account, target Target, image PreparedImage, caption string) (ImageSendResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.images = append(s.images, image)
+	s.captions = append(s.captions, caption)
+	if s.sendErr != nil {
+		return ImageSendResult{}, s.sendErr
+	}
+	return ImageSendResult{MessageID: "img_1"}, nil
+}
+
 func (s *stubAdapter) sentCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return len(s.messages)
 }
 
-func TestServiceUpdateDeliveryConfigPersistsSelection(t *testing.T) {
-	t.Parallel()
+func (s *stubAdapter) imageCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.images)
+}
+
+func newTestService(t *testing.T) (*Service, *settings.Store) {
+	t.Helper()
 
 	dsn := testmysql.NewDSN(t)
 	settingsStore, err := settings.NewStore(dsn)
 	if err != nil {
 		t.Fatalf("NewStore() error = %v", err)
 	}
-	service, err := NewService(dsn, settingsStore)
+	service, err := NewService(dsn, settingsStore, t.TempDir())
 	if err != nil {
 		t.Fatalf("NewService() error = %v", err)
 	}
+	return service, settingsStore
+}
+
+func TestServiceUpdateDeliveryConfigPersistsSelection(t *testing.T) {
+	t.Parallel()
+
+	service, _ := newTestService(t)
 
 	account, err := service.store.UpsertAccount("stub", "bot@im.bot", "user@im.wechat", "Bot", "https://example.com", "token")
 	if err != nil {
@@ -90,15 +116,7 @@ func TestServiceUpdateDeliveryConfigPersistsSelection(t *testing.T) {
 func TestServiceConfirmWeChatLoginPersistsAccountAfterExplicitConfirmation(t *testing.T) {
 	t.Parallel()
 
-	dsn := testmysql.NewDSN(t)
-	settingsStore, err := settings.NewStore(dsn)
-	if err != nil {
-		t.Fatalf("NewStore() error = %v", err)
-	}
-	service, err := NewService(dsn, settingsStore)
-	if err != nil {
-		t.Fatalf("NewService() error = %v", err)
-	}
+	service, _ := newTestService(t)
 
 	adapter := &stubAdapter{
 		loginResult: WeChatLoginResult{
@@ -159,15 +177,7 @@ func TestServiceConfirmWeChatLoginPersistsAccountAfterExplicitConfirmation(t *te
 func TestServiceSendTextToDefaultChannelUsesSavedSelectionEvenWhenMirrorDisabled(t *testing.T) {
 	t.Parallel()
 
-	dsn := testmysql.NewDSN(t)
-	settingsStore, err := settings.NewStore(dsn)
-	if err != nil {
-		t.Fatalf("NewStore() error = %v", err)
-	}
-	service, err := NewService(dsn, settingsStore)
-	if err != nil {
-		t.Fatalf("NewService() error = %v", err)
-	}
+	service, _ := newTestService(t)
 
 	adapter := &stubAdapter{}
 	service.adapters["stub"] = adapter
@@ -202,18 +212,59 @@ func TestServiceSendTextToDefaultChannelUsesSavedSelectionEvenWhenMirrorDisabled
 	}
 }
 
+func TestServiceSendImageToDefaultChannelUsesSavedSelectionEvenWhenMirrorDisabled(t *testing.T) {
+	t.Parallel()
+
+	service, _ := newTestService(t)
+
+	adapter := &stubAdapter{}
+	service.adapters["stub"] = adapter
+
+	account, err := service.store.UpsertAccount("stub", "bot@im.bot", "user@im.wechat", "Bot", "https://example.com", "token")
+	if err != nil {
+		t.Fatalf("UpsertAccount() error = %v", err)
+	}
+	target, err := service.store.UpsertTarget(account.ID, "我的微信", "user@im.wechat", true)
+	if err != nil {
+		t.Fatalf("UpsertTarget() error = %v", err)
+	}
+	if _, err := service.UpdateDeliveryConfig(false, account.ID, target.ID); err != nil {
+		t.Fatalf("UpdateDeliveryConfig() error = %v", err)
+	}
+
+	receipt, err := service.SendImageToDefaultChannel(ImageSendRequest{
+		FileName: "test.png",
+		MimeType: "image/png",
+		Content:  []byte{0x89, 0x50, 0x4e, 0x47},
+		Caption:  "图片调试消息",
+	})
+	if err != nil {
+		t.Fatalf("SendImageToDefaultChannel() error = %v", err)
+	}
+	if receipt.Account.ID != account.ID {
+		t.Fatalf("receipt.Account.ID = %q, want %q", receipt.Account.ID, account.ID)
+	}
+	if receipt.Target.ID != target.ID {
+		t.Fatalf("receipt.Target.ID = %q, want %q", receipt.Target.ID, target.ID)
+	}
+	if receipt.Kind != DeliveryKindImage {
+		t.Fatalf("receipt.Kind = %q, want %q", receipt.Kind, DeliveryKindImage)
+	}
+	if receipt.Caption != "图片调试消息" {
+		t.Fatalf("receipt.Caption = %q, want 图片调试消息", receipt.Caption)
+	}
+	if receipt.MediaFileName != "test.png" {
+		t.Fatalf("receipt.MediaFileName = %q, want test.png", receipt.MediaFileName)
+	}
+	if adapter.imageCount() != 1 {
+		t.Fatalf("imageCount() = %d, want 1", adapter.imageCount())
+	}
+}
+
 func TestServiceMirrorTextUpdatesDeliverySuccess(t *testing.T) {
 	t.Parallel()
 
-	dsn := testmysql.NewDSN(t)
-	settingsStore, err := settings.NewStore(dsn)
-	if err != nil {
-		t.Fatalf("NewStore() error = %v", err)
-	}
-	service, err := NewService(dsn, settingsStore)
-	if err != nil {
-		t.Fatalf("NewService() error = %v", err)
-	}
+	service, _ := newTestService(t)
 
 	adapter := &stubAdapter{}
 	service.adapters["stub"] = adapter
@@ -250,15 +301,7 @@ func TestServiceMirrorTextUpdatesDeliverySuccess(t *testing.T) {
 func TestServiceMirrorTextUpdatesDeliveryFailure(t *testing.T) {
 	t.Parallel()
 
-	dsn := testmysql.NewDSN(t)
-	settingsStore, err := settings.NewStore(dsn)
-	if err != nil {
-		t.Fatalf("NewStore() error = %v", err)
-	}
-	service, err := NewService(dsn, settingsStore)
-	if err != nil {
-		t.Fatalf("NewService() error = %v", err)
-	}
+	service, _ := newTestService(t)
 
 	adapter := &stubAdapter{sendErr: errors.New("boom")}
 	service.adapters["stub"] = adapter
@@ -295,15 +338,7 @@ func TestServiceMirrorTextUpdatesDeliveryFailure(t *testing.T) {
 func TestServiceDeleteAccountDisablesDelivery(t *testing.T) {
 	t.Parallel()
 
-	dsn := testmysql.NewDSN(t)
-	settingsStore, err := settings.NewStore(dsn)
-	if err != nil {
-		t.Fatalf("NewStore() error = %v", err)
-	}
-	service, err := NewService(dsn, settingsStore)
-	if err != nil {
-		t.Fatalf("NewService() error = %v", err)
-	}
+	service, settingsStore := newTestService(t)
 
 	account, err := service.store.UpsertAccount("stub", "bot@im.bot", "user@im.wechat", "Bot", "https://example.com", "token")
 	if err != nil {
@@ -333,15 +368,7 @@ func TestServiceDeleteAccountDisablesDelivery(t *testing.T) {
 func TestServiceDeleteNonSelectedTargetKeepsDeliverySelection(t *testing.T) {
 	t.Parallel()
 
-	dsn := testmysql.NewDSN(t)
-	settingsStore, err := settings.NewStore(dsn)
-	if err != nil {
-		t.Fatalf("NewStore() error = %v", err)
-	}
-	service, err := NewService(dsn, settingsStore)
-	if err != nil {
-		t.Fatalf("NewService() error = %v", err)
-	}
+	service, settingsStore := newTestService(t)
 
 	account, err := service.store.UpsertAccount("stub", "bot@im.bot", "user@im.wechat", "Bot", "https://example.com", "token")
 	if err != nil {
@@ -378,15 +405,7 @@ func TestServiceDeleteNonSelectedTargetKeepsDeliverySelection(t *testing.T) {
 func TestServiceDeleteSelectedTargetDisablesDelivery(t *testing.T) {
 	t.Parallel()
 
-	dsn := testmysql.NewDSN(t)
-	settingsStore, err := settings.NewStore(dsn)
-	if err != nil {
-		t.Fatalf("NewStore() error = %v", err)
-	}
-	service, err := NewService(dsn, settingsStore)
-	if err != nil {
-		t.Fatalf("NewService() error = %v", err)
-	}
+	service, settingsStore := newTestService(t)
 
 	account, err := service.store.UpsertAccount("stub", "bot@im.bot", "user@im.wechat", "Bot", "https://example.com", "token")
 	if err != nil {

--- a/internal/im/wechat_image.go
+++ b/internal/im/wechat_image.go
@@ -1,0 +1,223 @@
+package im
+
+import (
+	"bytes"
+	"context"
+	"crypto/aes"
+	"crypto/md5"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+)
+
+const weChatDefaultCDNBaseURL = "https://novac2c.cdn.weixin.qq.com/c2c"
+
+type weChatGetUploadURLResponse struct {
+	UploadParam    string `json:"upload_param"`
+	ThumbUploadURL string `json:"thumb_upload_param"`
+	UploadFullURL  string `json:"upload_full_url"`
+}
+
+type weChatUploadedImage struct {
+	FileKey                 string
+	DownloadEncryptedParam  string
+	AESKeyRaw               []byte
+	FileSizeCiphertextBytes int64
+}
+
+func (a *WeChatAdapter) SendImage(ctx context.Context, account Account, target Target, image PreparedImage, caption string) (ImageSendResult, error) {
+	if strings.TrimSpace(caption) != "" {
+		if _, err := a.SendText(ctx, account, target, caption); err != nil {
+			return ImageSendResult{}, err
+		}
+	}
+
+	uploaded, err := a.uploadImage(ctx, account, target, image)
+	if err != nil {
+		return ImageSendResult{}, err
+	}
+
+	clientID, err := randomWeChatToken(12)
+	if err != nil {
+		return ImageSendResult{}, err
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"msg": map[string]any{
+			"from_user_id":  "",
+			"to_user_id":    target.TargetUserID,
+			"client_id":     clientID,
+			"message_type":  2,
+			"message_state": 2,
+			"item_list": []map[string]any{
+				{
+					"type": 2,
+					"image_item": map[string]any{
+						"media": map[string]any{
+							"encrypt_query_param": uploaded.DownloadEncryptedParam,
+							"aes_key":             base64.StdEncoding.EncodeToString(uploaded.AESKeyRaw),
+							"encrypt_type":        1,
+						},
+						"mid_size": uploaded.FileSizeCiphertextBytes,
+					},
+				},
+			},
+		},
+		"base_info": map[string]any{
+			"channel_version": weChatDefaultChannelLabel,
+		},
+	})
+	if err != nil {
+		return ImageSendResult{}, fmt.Errorf("encode wechat image message body: %w", err)
+	}
+
+	if _, err := a.postJSON(ctx, account.BaseURL, "ilink/bot/sendmessage", account.Token, body); err != nil {
+		return ImageSendResult{}, err
+	}
+	return ImageSendResult{MessageID: clientID}, nil
+}
+
+func (a *WeChatAdapter) uploadImage(ctx context.Context, account Account, target Target, image PreparedImage) (weChatUploadedImage, error) {
+	content, err := os.ReadFile(image.FilePath)
+	if err != nil {
+		return weChatUploadedImage{}, fmt.Errorf("read image file: %w", err)
+	}
+
+	fileKey, err := randomWeChatToken(16)
+	if err != nil {
+		return weChatUploadedImage{}, err
+	}
+	aesKeyRaw := make([]byte, 16)
+	if _, err := rand.Read(aesKeyRaw); err != nil {
+		return weChatUploadedImage{}, fmt.Errorf("generate image aes key: %w", err)
+	}
+
+	rawSize := len(content)
+	rawMD5 := md5.Sum(content)
+	ciphertext, err := encryptWeChatAESECB(content, aesKeyRaw)
+	if err != nil {
+		return weChatUploadedImage{}, err
+	}
+
+	uploadMeta, err := a.getUploadURL(ctx, account, target, fileKey, rawSize, hex.EncodeToString(rawMD5[:]), len(ciphertext), hex.EncodeToString(aesKeyRaw))
+	if err != nil {
+		return weChatUploadedImage{}, err
+	}
+	downloadParam, err := a.uploadImageCiphertext(ctx, uploadMeta, fileKey, ciphertext)
+	if err != nil {
+		return weChatUploadedImage{}, err
+	}
+
+	return weChatUploadedImage{
+		FileKey:                 fileKey,
+		DownloadEncryptedParam:  downloadParam,
+		AESKeyRaw:               aesKeyRaw,
+		FileSizeCiphertextBytes: int64(len(ciphertext)),
+	}, nil
+}
+
+func (a *WeChatAdapter) getUploadURL(ctx context.Context, account Account, target Target, fileKey string, rawSize int, rawMD5 string, cipherSize int, aesKeyHex string) (weChatGetUploadURLResponse, error) {
+	body, err := json.Marshal(map[string]any{
+		"filekey":       fileKey,
+		"media_type":    1,
+		"to_user_id":    target.TargetUserID,
+		"rawsize":       rawSize,
+		"rawfilemd5":    rawMD5,
+		"filesize":      cipherSize,
+		"no_need_thumb": true,
+		"aeskey":        aesKeyHex,
+		"base_info": map[string]any{
+			"channel_version": weChatDefaultChannelLabel,
+		},
+	})
+	if err != nil {
+		return weChatGetUploadURLResponse{}, fmt.Errorf("encode wechat upload url request: %w", err)
+	}
+
+	respBody, err := a.postJSON(ctx, account.BaseURL, "ilink/bot/getuploadurl", account.Token, body)
+	if err != nil {
+		return weChatGetUploadURLResponse{}, err
+	}
+
+	var resp weChatGetUploadURLResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return weChatGetUploadURLResponse{}, fmt.Errorf("decode wechat upload url response: %w", err)
+	}
+	if strings.TrimSpace(resp.UploadFullURL) == "" && strings.TrimSpace(resp.UploadParam) == "" {
+		return weChatGetUploadURLResponse{}, fmt.Errorf("wechat upload url response is missing upload_full_url and upload_param")
+	}
+	return resp, nil
+}
+
+func (a *WeChatAdapter) uploadImageCiphertext(ctx context.Context, uploadMeta weChatGetUploadURLResponse, fileKey string, ciphertext []byte) (string, error) {
+	uploadURL := strings.TrimSpace(uploadMeta.UploadFullURL)
+	if uploadURL == "" {
+		uploadURL = buildWeChatCDNUploadURL(strings.TrimSpace(uploadMeta.UploadParam), fileKey)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadURL, bytes.NewReader(ciphertext))
+	if err != nil {
+		return "", fmt.Errorf("build wechat cdn upload request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("wechat cdn upload failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read wechat cdn upload response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		message := strings.TrimSpace(resp.Header.Get("x-error-message"))
+		if message == "" {
+			message = strings.TrimSpace(string(respBody))
+		}
+		return "", fmt.Errorf("wechat cdn upload failed: status=%d body=%s", resp.StatusCode, message)
+	}
+
+	downloadParam := strings.TrimSpace(resp.Header.Get("x-encrypted-param"))
+	if downloadParam == "" {
+		return "", fmt.Errorf("wechat cdn upload response is missing x-encrypted-param")
+	}
+	return downloadParam, nil
+}
+
+func buildWeChatCDNUploadURL(uploadParam string, fileKey string) string {
+	return fmt.Sprintf("%s/upload?encrypted_query_param=%s&filekey=%s", weChatDefaultCDNBaseURL, url.QueryEscape(uploadParam), url.QueryEscape(fileKey))
+}
+
+func encryptWeChatAESECB(plaintext []byte, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("create aes cipher: %w", err)
+	}
+	padded := pkcs7Pad(plaintext, block.BlockSize())
+	ciphertext := make([]byte, len(padded))
+	for start := 0; start < len(padded); start += block.BlockSize() {
+		block.Encrypt(ciphertext[start:start+block.BlockSize()], padded[start:start+block.BlockSize()])
+	}
+	return ciphertext, nil
+}
+
+func pkcs7Pad(plaintext []byte, blockSize int) []byte {
+	padding := blockSize - (len(plaintext) % blockSize)
+	if padding == 0 {
+		padding = blockSize
+	}
+	result := make([]byte, len(plaintext)+padding)
+	copy(result, plaintext)
+	for i := len(plaintext); i < len(result); i++ {
+		result[i] = byte(padding)
+	}
+	return result
+}

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	imService, err := im.NewService(dsn, settingsStore)
+	imService, err := im.NewService(dsn, settingsStore, appConfig.IM.MediaCacheDir)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/web/src/components/settings/IMDebugSendPanel.tsx
+++ b/web/src/components/settings/IMDebugSendPanel.tsx
@@ -5,11 +5,20 @@ type Props = {
   target: IMTarget | null
   configDirty: boolean
   text: string
-  sending: boolean
-  feedback: string | null
-  error: string | null
+  textSending: boolean
+  textFeedback: string | null
+  textError: string | null
+  imageCaption: string
+  imageFileName: string | null
+  imageInputKey: number
+  imageSending: boolean
+  imageFeedback: string | null
+  imageError: string | null
   onTextChange: (value: string) => void
-  onSend: () => void
+  onSendText: () => void
+  onImageCaptionChange: (value: string) => void
+  onImageFileChange: (file: File | null) => void
+  onSendImage: () => void
 }
 
 export function IMDebugSendPanel({
@@ -17,11 +26,20 @@ export function IMDebugSendPanel({
   target,
   configDirty,
   text,
-  sending,
-  feedback,
-  error,
+  textSending,
+  textFeedback,
+  textError,
+  imageCaption,
+  imageFileName,
+  imageInputKey,
+  imageSending,
+  imageFeedback,
+  imageError,
   onTextChange,
-  onSend,
+  onSendText,
+  onImageCaptionChange,
+  onImageFileChange,
+  onSendImage,
 }: Props) {
   const ready = Boolean(account && target)
 
@@ -68,7 +86,7 @@ export function IMDebugSendPanel({
           <span>测试文本</span>
           <textarea
             className="settings-textarea"
-            disabled={!ready || sending}
+            disabled={!ready || textSending}
             placeholder="例如：这是一条默认渠道调试消息。"
             rows={4}
             value={text}
@@ -79,17 +97,59 @@ export function IMDebugSendPanel({
         <div className="settings-actions">
           <button
             className="settings-button"
-            disabled={!ready || sending || !text.trim()}
-            onClick={() => onSend()}
+            disabled={!ready || textSending || !text.trim()}
+            onClick={() => onSendText()}
             type="button"
           >
-            {sending ? '发送中...' : '发送测试消息'}
+            {textSending ? '发送中...' : '发送测试消息'}
           </button>
-          <span className="settings-note">当前阶段只支持文本消息。</span>
+          <span className="settings-note">这条链路会同步验证默认渠道是否真的可用。</span>
         </div>
 
-        {feedback ? <div className="settings-feedback">{feedback}</div> : null}
-        {error ? <div className="error-banner settings-error">{error}</div> : null}
+        {textFeedback ? <div className="settings-feedback">{textFeedback}</div> : null}
+        {textError ? <div className="error-banner settings-error">{textError}</div> : null}
+
+        <label className="settings-field">
+          <span>测试图片</span>
+          <input
+            accept="image/*"
+            className="settings-input"
+            disabled={!ready || imageSending}
+            key={imageInputKey}
+            type="file"
+            onChange={(event) => onImageFileChange(event.target.files?.[0] ?? null)}
+          />
+          <span className="settings-note">
+            {imageFileName ? `已选择：${imageFileName}` : '只接受图片文件，服务端会先落到媒体缓存目录，再按微信协议发送。'}
+          </span>
+        </label>
+
+        <label className="settings-field">
+          <span>图片说明</span>
+          <textarea
+            className="settings-textarea"
+            disabled={!ready || imageSending}
+            placeholder="例如：这是一张默认渠道调试图片。"
+            rows={3}
+            value={imageCaption}
+            onChange={(event) => onImageCaptionChange(event.target.value)}
+          />
+        </label>
+
+        <div className="settings-actions">
+          <button
+            className="settings-button"
+            disabled={!ready || imageSending || !imageFileName}
+            onClick={() => onSendImage()}
+            type="button"
+          >
+            {imageSending ? '发送中...' : '发送测试图片'}
+          </button>
+          <span className="settings-note">如果填写了图片说明，微信侧会先收到一条文字，再收到图片。</span>
+        </div>
+
+        {imageFeedback ? <div className="settings-feedback">{imageFeedback}</div> : null}
+        {imageError ? <div className="error-banner settings-error">{imageError}</div> : null}
       </div>
     </article>
   )

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -24,3 +24,13 @@ export async function postJSON<T>(url: string, payload: unknown) {
   return (await response.json()) as T
 }
 
+export async function postFormData<T>(url: string, payload: FormData) {
+  const response = await fetch(url, {
+    method: 'POST',
+    body: payload,
+  })
+  if (!response.ok) {
+    throw new Error(await response.text())
+  }
+  return (await response.json()) as T
+}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -5,7 +5,7 @@ import { IMTargetsPanel } from '../components/settings/IMTargetsPanel'
 import { SessionSettingsPanel } from '../components/settings/SessionSettingsPanel'
 import { WeChatAccountsPanel } from '../components/settings/WeChatAccountsPanel'
 import { WeChatLoginPanel } from '../components/settings/WeChatLoginPanel'
-import { postJSON } from '../lib/api'
+import { postFormData, postJSON } from '../lib/api'
 import { normalizeSettings, selectBestTarget } from '../lib/dashboard'
 import type {
   DashboardState,
@@ -94,9 +94,15 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
   const [deliveryFeedback, setDeliveryFeedback] = useState<string | null>(null)
   const [deliveryError, setDeliveryError] = useState<string | null>(null)
   const [debugText, setDebugText] = useState('')
-  const [debugSending, setDebugSending] = useState(false)
-  const [debugFeedback, setDebugFeedback] = useState<string | null>(null)
-  const [debugError, setDebugError] = useState<string | null>(null)
+  const [debugTextSending, setDebugTextSending] = useState(false)
+  const [debugTextFeedback, setDebugTextFeedback] = useState<string | null>(null)
+  const [debugTextError, setDebugTextError] = useState<string | null>(null)
+  const [debugImageFile, setDebugImageFile] = useState<File | null>(null)
+  const [debugImageCaption, setDebugImageCaption] = useState('')
+  const [debugImageInputKey, setDebugImageInputKey] = useState(0)
+  const [debugImageSending, setDebugImageSending] = useState(false)
+  const [debugImageFeedback, setDebugImageFeedback] = useState<string | null>(null)
+  const [debugImageError, setDebugImageError] = useState<string | null>(null)
 
   const [loginPanel, setLoginPanel] = useState<LoginPanelState>(emptyLoginState)
 
@@ -407,14 +413,14 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
 
   async function sendDebugText() {
     if (!debugText.trim()) {
-      setDebugError('请输入要发送的测试文本。')
-      setDebugFeedback(null)
+      setDebugTextError('请输入要发送的测试文本。')
+      setDebugTextFeedback(null)
       return
     }
 
-    setDebugSending(true)
-    setDebugError(null)
-    setDebugFeedback(null)
+    setDebugTextSending(true)
+    setDebugTextError(null)
+    setDebugTextFeedback(null)
     try {
       const payload = await postJSON<{ receipt?: IMDeliveryReceipt }>('/api/im/debug/send-default', {
         text: debugText,
@@ -422,14 +428,47 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
       await refresh()
       setDebugText('')
       if (payload.receipt) {
-        setDebugFeedback(`测试消息已发送到 ${payload.receipt.account.display_name || payload.receipt.account.remote_account_id} / ${payload.receipt.target.name}。`)
+        setDebugTextFeedback(`测试消息已发送到 ${payload.receipt.account.display_name || payload.receipt.account.remote_account_id} / ${payload.receipt.target.name}。`)
       } else {
-        setDebugFeedback('测试消息发送成功。')
+        setDebugTextFeedback('测试消息发送成功。')
       }
     } catch (err) {
-      setDebugError(err instanceof Error ? err.message : '发送测试消息失败')
+      setDebugTextError(err instanceof Error ? err.message : '发送测试消息失败')
     } finally {
-      setDebugSending(false)
+      setDebugTextSending(false)
+    }
+  }
+
+  async function sendDebugImage() {
+    if (!debugImageFile) {
+      setDebugImageError('请先选择一张图片。')
+      setDebugImageFeedback(null)
+      return
+    }
+
+    const payload = new FormData()
+    payload.set('file', debugImageFile)
+    payload.set('caption', debugImageCaption)
+
+    setDebugImageSending(true)
+    setDebugImageError(null)
+    setDebugImageFeedback(null)
+    try {
+      const result = await postFormData<{ receipt?: IMDeliveryReceipt }>('/api/im/debug/send-image-default', payload)
+      await refresh()
+      setDebugImageFile(null)
+      setDebugImageCaption('')
+      setDebugImageInputKey((current) => current + 1)
+      if (result.receipt) {
+        const label = result.receipt.media_file_name || debugImageFile.name
+        setDebugImageFeedback(`测试图片 ${label} 已发送到 ${result.receipt.account.display_name || result.receipt.account.remote_account_id} / ${result.receipt.target.name}。`)
+      } else {
+        setDebugImageFeedback('测试图片发送成功。')
+      }
+    } catch (err) {
+      setDebugImageError(err instanceof Error ? err.message : '发送测试图片失败')
+    } finally {
+      setDebugImageSending(false)
     }
   }
 
@@ -552,16 +591,33 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
               <IMDebugSendPanel
                 account={savedDebugAccount}
                 configDirty={deliveryDirty}
-                error={debugError}
-                feedback={debugFeedback}
-                sending={debugSending}
+                imageCaption={debugImageCaption}
+                imageError={debugImageError}
+                imageFeedback={debugImageFeedback}
+                imageFileName={debugImageFile?.name ?? null}
+                imageInputKey={debugImageInputKey}
+                imageSending={debugImageSending}
                 target={savedDebugTarget}
                 text={debugText}
-                onSend={() => void sendDebugText()}
+                textError={debugTextError}
+                textFeedback={debugTextFeedback}
+                textSending={debugTextSending}
+                onImageCaptionChange={(value) => {
+                  setDebugImageCaption(value)
+                  setDebugImageFeedback(null)
+                  setDebugImageError(null)
+                }}
+                onImageFileChange={(file) => {
+                  setDebugImageFile(file)
+                  setDebugImageFeedback(null)
+                  setDebugImageError(null)
+                }}
+                onSendImage={() => void sendDebugImage()}
+                onSendText={() => void sendDebugText()}
                 onTextChange={(value) => {
                   setDebugText(value)
-                  setDebugFeedback(null)
-                  setDebugError(null)
+                  setDebugTextFeedback(null)
+                  setDebugTextError(null)
                 }}
               />
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -108,7 +108,11 @@ export type IMDeliveryReceipt = {
   account: IMAccount
   target: IMTarget
   message_id: string
-  text: string
+  kind: 'text' | 'image'
+  text?: string
+  caption?: string
+  media_file_name?: string
+  media_mime_type?: string
 }
 
 export type WeChatLoginStart = {


### PR DESCRIPTION
## 背景
- 补齐 IM 网关默认渠道的图片发送能力
- 让媒体缓存目录可以通过 config.yaml 配置
- 保持当前缓存文件默认不自动清理

## 变更
- 后端新增 `SendImageToDefaultChannel` 与 `/api/im/debug/send-image-default` multipart 调试接口
- 增加媒体缓存组件，上传图片会先落到 `im.media_cache_dir` 指定目录
- 微信 adapter 按微信协议补齐图片上传 CDN 与 `image_item` 发送链路
- 设置页新增默认渠道图片调试发送入口，并保留文本调试发送
- 同步补充配置测试、dashboard 测试，以及 README / AGENTS 文档

## 验证
- `GOCACHE=$(pwd)/.gocache go test ./...`
- `npm run build:web`

Closes #14