### PR TITLE
feat: 增加后端日志中心与分页查看能力

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Current responsibilities:
 - drive local TTS playback on the device through the existing client protocol
 - maintain lightweight async tasks
 - provide phase-1 IM gateway capability for WeChat text delivery plus default-channel image debug send
+- persist backend runtime logs and expose them through the dashboard API
 - expose a React dashboard over API + web frontend
 
 Current non-goals / known missing pieces:
@@ -89,6 +90,10 @@ Only the high-signal parts are listed here.
   - single text playback + streamed chunk playback
 - `internal/dashboard`
   - API side for dashboard state
+- `internal/logs`
+  - backend runtime log persistence
+  - standard logger capture
+  - paginated log listing
 - `internal/im`
   - phase-1 IM gateway
   - WeChat login / account / target / mirror delivery
@@ -169,6 +174,7 @@ Logical stores:
 - sliding-window conversation history
 - Claude plugin private state
 - runtime settings such as `session.window_seconds`
+- backend runtime logs
 - IM gateway accounts / targets / events
 
 ### Meaning of Each Store
@@ -209,6 +215,17 @@ Media cache:
 - cache directory comes from `config.yaml` field `im.media_cache_dir`
 - current default is `.cache/im-media` under the repo root
 - files are intentionally not auto-cleaned yet
+
+Runtime log store:
+
+- backend standard logger output is persisted to MySQL
+- each log row keeps:
+  - timestamp
+  - inferred level
+  - source file/line when available
+  - parsed message
+  - raw formatted line
+- dashboard reads logs through a dedicated paginated API
 
 Claude-private store:
 
@@ -441,6 +458,7 @@ Go provides the dashboard API only.
 Important routes:
 
 - `GET /api/healthz`
+- `GET /api/logs`
 - `GET /api/state`
 - `GET /api/settings`
 - `POST /api/settings/session`
@@ -464,6 +482,7 @@ UI decisions that were explicitly requested:
 - task event flow belongs to a selected task
 - conversation history is shown separately
 - settings should live on a separate settings page
+- backend logs should live on their own page and not be mixed into `/api/state`
 - dashboard should feel intentional, not generic admin boilerplate
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ flowchart TD
 - 使用 `reply` 模型流式生成回复，并通过设备侧 TTS 播放
 - 管理轻量异步任务，并在后续对话中补报进度
 - 提供独立的 React + Vite dashboard
+- 提供后端日志中心，可在管理界面分页查看 Go server 日志
 - 使用 MySQL 保存任务、会话和插件私有状态
 - 会话上下文默认使用滑动窗口，并支持在 Dashboard 中调整窗口秒数
 - 提供第一期独立 IM Gateway：支持微信扫码登录、确认添加账号、多账号管理、文本触达配置，以及默认渠道的文本 / 图片调试发送
@@ -182,6 +183,7 @@ npm run dev
 - Dashboard API: `:8090`
 - Web dashboard: `http://127.0.0.1:5173/#/`
 - Settings page: `http://127.0.0.1:5173/#/settings`
+- Logs page: `http://127.0.0.1:5173/#/logs`
 
 如果只启动后端：
 
@@ -251,6 +253,7 @@ npm run build:web
 Go 后端只提供 API，前端位于 `web/`。
 
 - `GET /api/healthz`
+- `GET /api/logs`
 - `GET /api/state`
 - `GET /api/settings`
 - `POST /api/settings/session`
@@ -276,7 +279,7 @@ npm run build:web
 
 - 当前 IM Gateway 第一期只做微信文本触达
 - 还没有 IM 入站会话
-- 还没有媒体发送
+- 还没有自动媒体镜像或更通用的媒体投递编排
 - 还没有群聊路由
 - 还没有完善的人声打断检测
 - 当前依赖外部 MySQL 服务

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -6,9 +6,11 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strconv"
 
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/assistant"
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/im"
+	runtimelogs "github.com/luoliwoshang/open-xiaoai-agent/internal/logs"
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/plugins/complextask"
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/settings"
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/tasks"
@@ -40,6 +42,9 @@ type Server struct {
 		UpdateDeliveryConfig(enabled bool, accountID string, targetID string) (settings.Snapshot, error)
 		Reset() error
 	}
+	logs interface {
+		List(query runtimelogs.ListQuery) (runtimelogs.ListPage, error)
+	}
 }
 
 func New(addr string, tasks *tasks.Manager, claude *complextask.Service, conversations interface {
@@ -61,6 +66,8 @@ func New(addr string, tasks *tasks.Manager, claude *complextask.Service, convers
 	DeleteAccount(accountID string) error
 	UpdateDeliveryConfig(enabled bool, accountID string, targetID string) (settings.Snapshot, error)
 	Reset() error
+}, logStore interface {
+	List(query runtimelogs.ListQuery) (runtimelogs.ListPage, error)
 }) *Server {
 	return &Server{
 		addr:          addr,
@@ -69,6 +76,7 @@ func New(addr string, tasks *tasks.Manager, claude *complextask.Service, convers
 		conversations: conversations,
 		settings:      runtimeSettings,
 		im:            imGateway,
+		logs:          logStore,
 	}
 }
 
@@ -76,6 +84,7 @@ func (s *Server) ListenAndServe() error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/healthz", s.handleHealth)
 	mux.HandleFunc("/api/state", s.handleState)
+	mux.HandleFunc("/api/logs", s.handleLogs)
 	mux.HandleFunc("/api/settings", s.handleSettings)
 	mux.HandleFunc("/api/settings/session", s.handleSessionSettings)
 	mux.HandleFunc("/api/settings/im-delivery", s.handleIMDeliverySettings)
@@ -120,6 +129,54 @@ func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
 		"settings":       runtimeSettings,
 		"im":             imState,
 	})
+}
+
+func (s *Server) handleLogs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.logs == nil {
+		http.Error(w, "runtime logs are not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	page := 1
+	if raw := r.URL.Query().Get("page"); raw != "" {
+		value, err := strconv.Atoi(raw)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("invalid page: %v", err), http.StatusBadRequest)
+			return
+		}
+		page = value
+	}
+
+	pageSize := runtimelogs.DefaultPageSize
+	if raw := r.URL.Query().Get("page_size"); raw != "" {
+		value, err := strconv.Atoi(raw)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("invalid page_size: %v", err), http.StatusBadRequest)
+			return
+		}
+		pageSize = value
+	}
+
+	query, err := runtimelogs.NormalizeQuery(runtimelogs.ListQuery{
+		Page:     page,
+		PageSize: pageSize,
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	logPage, err := s.logs.List(query)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, logPage)
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {

--- a/internal/dashboard/server_test.go
+++ b/internal/dashboard/server_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/assistant"
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/im"
+	runtimelogs "github.com/luoliwoshang/open-xiaoai-agent/internal/logs"
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/plugin"
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/plugins/complextask"
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/settings"
@@ -68,6 +69,33 @@ type fakeIM struct {
 	debugImage      im.ImageSendRequest
 	debugReceipt    im.DeliveryReceipt
 	resetCalls      int
+}
+
+type fakeLogs struct {
+	lastQuery runtimelogs.ListQuery
+	page      runtimelogs.ListPage
+}
+
+func (f *fakeLogs) List(query runtimelogs.ListQuery) (runtimelogs.ListPage, error) {
+	f.lastQuery = query
+	if f.page.Page == 0 {
+		f.page = runtimelogs.ListPage{
+			Page:     query.Page,
+			PageSize: query.PageSize,
+			Total:    1,
+			HasMore:  false,
+			Items: []runtimelogs.Entry{
+				{
+					ID:      "log_1",
+					Level:   "error",
+					Source:  "assistant/service.go:141",
+					Message: "intent classify failed",
+					Raw:     "2026/04/28 12:00:00.000000 assistant/service.go:141: intent classify failed",
+				},
+			},
+		}
+	}
+	return f.page, nil
 }
 
 func (f *fakeIM) Snapshot() im.Snapshot {
@@ -214,7 +242,7 @@ func TestHandleResetClearsRuntimeData(t *testing.T) {
 	}
 
 	imGateway := &fakeIM{}
-	server := New(":0", manager, claude, conversations, runtimeSettings, imGateway)
+	server := New(":0", manager, claude, conversations, runtimeSettings, imGateway, &fakeLogs{})
 	req := httptest.NewRequest(http.MethodPost, "/api/reset", nil)
 	recorder := httptest.NewRecorder()
 
@@ -245,7 +273,7 @@ func TestHandleResetClearsRuntimeData(t *testing.T) {
 func TestHandleResetRejectsNonPost(t *testing.T) {
 	t.Parallel()
 
-	server := New(":0", nil, nil, &fakeConversations{}, &fakeSettings{snapshot: settings.Snapshot{SessionWindowSeconds: 300}}, &fakeIM{})
+	server := New(":0", nil, nil, &fakeConversations{}, &fakeSettings{snapshot: settings.Snapshot{SessionWindowSeconds: 300}}, &fakeIM{}, &fakeLogs{})
 	req := httptest.NewRequest(http.MethodGet, "/api/reset", nil)
 	recorder := httptest.NewRecorder()
 
@@ -259,7 +287,7 @@ func TestHandleResetRejectsNonPost(t *testing.T) {
 func TestHandleSettingsReturnsSnapshot(t *testing.T) {
 	t.Parallel()
 
-	server := New(":0", nil, nil, nil, &fakeSettings{snapshot: settings.Snapshot{SessionWindowSeconds: 300}}, &fakeIM{})
+	server := New(":0", nil, nil, nil, &fakeSettings{snapshot: settings.Snapshot{SessionWindowSeconds: 300}}, &fakeIM{}, &fakeLogs{})
 	req := httptest.NewRequest(http.MethodGet, "/api/settings", nil)
 	recorder := httptest.NewRecorder()
 
@@ -284,7 +312,7 @@ func TestHandleSessionSettingsUpdatesWindowSeconds(t *testing.T) {
 	t.Parallel()
 
 	runtimeSettings := &fakeSettings{snapshot: settings.Snapshot{SessionWindowSeconds: 300}}
-	server := New(":0", nil, nil, nil, runtimeSettings, &fakeIM{})
+	server := New(":0", nil, nil, nil, runtimeSettings, &fakeIM{}, &fakeLogs{})
 	req := httptest.NewRequest(http.MethodPost, "/api/settings/session", strings.NewReader(`{"window_seconds":420}`))
 	recorder := httptest.NewRecorder()
 
@@ -301,7 +329,7 @@ func TestHandleSessionSettingsUpdatesWindowSeconds(t *testing.T) {
 func TestHandleSessionSettingsRejectsInvalidValue(t *testing.T) {
 	t.Parallel()
 
-	server := New(":0", nil, nil, nil, &fakeSettings{snapshot: settings.Snapshot{SessionWindowSeconds: 300}}, &fakeIM{})
+	server := New(":0", nil, nil, nil, &fakeSettings{snapshot: settings.Snapshot{SessionWindowSeconds: 300}}, &fakeIM{}, &fakeLogs{})
 	req := httptest.NewRequest(http.MethodPost, "/api/settings/session", strings.NewReader(`{"window_seconds":1}`))
 	recorder := httptest.NewRecorder()
 
@@ -316,7 +344,7 @@ func TestHandleWeChatLoginConfirmPersistsAfterExplicitConfirmation(t *testing.T)
 	t.Parallel()
 
 	imGateway := &fakeIM{}
-	server := New(":0", nil, nil, nil, &fakeSettings{snapshot: settings.Snapshot{SessionWindowSeconds: 300}}, imGateway)
+	server := New(":0", nil, nil, nil, &fakeSettings{snapshot: settings.Snapshot{SessionWindowSeconds: 300}}, imGateway, &fakeLogs{})
 	req := httptest.NewRequest(http.MethodPost, "/api/im/wechat/login/confirm", strings.NewReader(`{"session_key":"sess-1"}`))
 	recorder := httptest.NewRecorder()
 
@@ -348,7 +376,7 @@ func TestHandleIMDebugSendDefaultUsesPostedText(t *testing.T) {
 	t.Parallel()
 
 	imGateway := &fakeIM{}
-	server := New(":0", nil, nil, nil, &fakeSettings{snapshot: settings.Snapshot{SessionWindowSeconds: 300}}, imGateway)
+	server := New(":0", nil, nil, nil, &fakeSettings{snapshot: settings.Snapshot{SessionWindowSeconds: 300}}, imGateway, &fakeLogs{})
 	req := httptest.NewRequest(http.MethodPost, "/api/im/debug/send-default", strings.NewReader(`{"text":"调试消息"}`))
 	recorder := httptest.NewRecorder()
 
@@ -383,7 +411,7 @@ func TestHandleIMDebugSendImageDefaultUsesUploadedFile(t *testing.T) {
 	t.Parallel()
 
 	imGateway := &fakeIM{}
-	server := New(":0", nil, nil, nil, &fakeSettings{snapshot: settings.Snapshot{SessionWindowSeconds: 300}}, imGateway)
+	server := New(":0", nil, nil, nil, &fakeSettings{snapshot: settings.Snapshot{SessionWindowSeconds: 300}}, imGateway, &fakeLogs{})
 
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
@@ -435,5 +463,51 @@ func TestHandleIMDebugSendImageDefaultUsesUploadedFile(t *testing.T) {
 	}
 	if payload.Receipt.MediaFileName != "rabbit.png" {
 		t.Fatalf("MediaFileName = %q, want rabbit.png", payload.Receipt.MediaFileName)
+	}
+}
+
+func TestHandleLogsReturnsPaginatedEntries(t *testing.T) {
+	t.Parallel()
+
+	logStore := &fakeLogs{}
+	server := New(":0", nil, nil, nil, &fakeSettings{snapshot: settings.Snapshot{SessionWindowSeconds: 300}}, &fakeIM{}, logStore)
+	req := httptest.NewRequest(http.MethodGet, "/api/logs?page=2&page_size=25", nil)
+	recorder := httptest.NewRecorder()
+
+	server.handleLogs(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if logStore.lastQuery.Page != 2 {
+		t.Fatalf("Page = %d, want 2", logStore.lastQuery.Page)
+	}
+	if logStore.lastQuery.PageSize != 25 {
+		t.Fatalf("PageSize = %d, want 25", logStore.lastQuery.PageSize)
+	}
+
+	var payload runtimelogs.ListPage
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if len(payload.Items) != 1 {
+		t.Fatalf("len(Items) = %d, want 1", len(payload.Items))
+	}
+	if payload.Items[0].Source != "assistant/service.go:141" {
+		t.Fatalf("Source = %q, want assistant/service.go:141", payload.Items[0].Source)
+	}
+}
+
+func TestHandleLogsRejectsInvalidPage(t *testing.T) {
+	t.Parallel()
+
+	server := New(":0", nil, nil, nil, &fakeSettings{snapshot: settings.Snapshot{SessionWindowSeconds: 300}}, &fakeIM{}, &fakeLogs{})
+	req := httptest.NewRequest(http.MethodGet, "/api/logs?page=oops", nil)
+	recorder := httptest.NewRecorder()
+
+	server.handleLogs(recorder, req)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
 	}
 }

--- a/internal/logs/model.go
+++ b/internal/logs/model.go
@@ -1,0 +1,63 @@
+package logs
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultPageSize = 50
+	MaxPageSize     = 200
+)
+
+type Entry struct {
+	ID        string    `json:"id"`
+	Level     string    `json:"level"`
+	Source    string    `json:"source"`
+	Message   string    `json:"message"`
+	Raw       string    `json:"raw"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type ListQuery struct {
+	Page     int
+	PageSize int
+}
+
+type ListPage struct {
+	Items    []Entry `json:"items"`
+	Page     int     `json:"page"`
+	PageSize int     `json:"page_size"`
+	Total    int     `json:"total"`
+	HasMore  bool    `json:"has_more"`
+}
+
+func NormalizeQuery(query ListQuery) (ListQuery, error) {
+	if query.Page == 0 {
+		query.Page = 1
+	}
+	if query.PageSize == 0 {
+		query.PageSize = DefaultPageSize
+	}
+	switch {
+	case query.Page < 1:
+		return ListQuery{}, fmt.Errorf("page must be at least 1")
+	case query.PageSize < 1:
+		return ListQuery{}, fmt.Errorf("page size must be at least 1")
+	case query.PageSize > MaxPageSize:
+		return ListQuery{}, fmt.Errorf("page size must be at most %d", MaxPageSize)
+	default:
+		return query, nil
+	}
+}
+
+func normalizeLevel(value string) string {
+	value = strings.TrimSpace(strings.ToLower(value))
+	switch value {
+	case "debug", "info", "warn", "error", "fatal":
+		return value
+	default:
+		return "info"
+	}
+}

--- a/internal/logs/recorder.go
+++ b/internal/logs/recorder.go
@@ -1,0 +1,121 @@
+package logs
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+)
+
+const standardLogTimeLayout = "2006/01/02 15:04:05.000000"
+
+type Recorder struct {
+	mu        sync.Mutex
+	out       io.Writer
+	store     *Store
+	remainder []byte
+	now       func() time.Time
+}
+
+func NewRecorder(store *Store, out io.Writer) *Recorder {
+	return &Recorder{
+		out:   out,
+		store: store,
+		now:   time.Now,
+	}
+}
+
+func (r *Recorder) Write(p []byte) (int, error) {
+	if r == nil {
+		return len(p), nil
+	}
+	if r.out != nil {
+		if _, err := r.out.Write(p); err != nil {
+			return 0, err
+		}
+	}
+
+	lines := r.collectLines(p)
+	for _, line := range lines {
+		entry := r.parseLine(line)
+		if entry.Raw == "" {
+			continue
+		}
+		if r.store == nil {
+			continue
+		}
+		if err := r.store.Append(entry); err != nil && r.out != nil {
+			_, _ = fmt.Fprintf(r.out, "runtime log persist failed: %v\n", err)
+		}
+	}
+	return len(p), nil
+}
+
+func (r *Recorder) collectLines(p []byte) []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.remainder = append(r.remainder, p...)
+	var lines []string
+	for {
+		index := bytes.IndexByte(r.remainder, '\n')
+		if index < 0 {
+			break
+		}
+		line := strings.TrimRight(string(r.remainder[:index]), "\r")
+		r.remainder = append([]byte(nil), r.remainder[index+1:]...)
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+func (r *Recorder) parseLine(line string) Entry {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return Entry{}
+	}
+
+	entry := Entry{
+		Level:     inferLevel(line),
+		Raw:       line,
+		Message:   line,
+		CreatedAt: r.now(),
+	}
+	if len(line) < len(standardLogTimeLayout) {
+		return entry
+	}
+
+	if createdAt, err := time.ParseInLocation(standardLogTimeLayout, line[:len(standardLogTimeLayout)], time.Local); err == nil {
+		entry.CreatedAt = createdAt
+		rest := strings.TrimSpace(line[len(standardLogTimeLayout):])
+		if rest != "" {
+			if index := strings.Index(rest, ": "); index >= 0 {
+				entry.Source = strings.TrimSpace(rest[:index])
+				entry.Message = strings.TrimSpace(rest[index+2:])
+				entry.Level = inferLevel(entry.Message)
+				return entry
+			}
+			entry.Message = rest
+			entry.Level = inferLevel(rest)
+		}
+	}
+	return entry
+}
+
+func inferLevel(text string) string {
+	value := strings.ToLower(strings.TrimSpace(text))
+	switch {
+	case strings.Contains(value, "panic"), strings.Contains(value, "fatal"):
+		return "fatal"
+	case strings.Contains(value, "error"), strings.Contains(value, "failed"), strings.Contains(value, "invalid"):
+		return "error"
+	case strings.Contains(value, "warn"), strings.Contains(value, "timeout"), strings.Contains(value, "dropped"):
+		return "warn"
+	case strings.Contains(value, "debug"):
+		return "debug"
+	default:
+		return "info"
+	}
+}

--- a/internal/logs/recorder_test.go
+++ b/internal/logs/recorder_test.go
@@ -1,0 +1,85 @@
+package logs
+
+import (
+	"bytes"
+	"fmt"
+	stdlog "log"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luoliwoshang/open-xiaoai-agent/internal/testmysql"
+)
+
+func TestRecorderPersistsStandardLogLines(t *testing.T) {
+	t.Parallel()
+
+	store, err := NewStore(testmysql.NewDSN(t))
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	var sink bytes.Buffer
+	recorder := NewRecorder(store, &sink)
+
+	logger := stdlog.New(recorder, "", stdlog.LstdFlags|stdlog.Lmicroseconds|stdlog.Lshortfile)
+	logger.Printf("test recorder message %d", 42)
+
+	page, err := store.List(ListQuery{Page: 1, PageSize: 10})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(page.Items) != 1 {
+		t.Fatalf("len(Items) = %d, want 1", len(page.Items))
+	}
+	if !strings.Contains(page.Items[0].Message, "test recorder message 42") {
+		t.Fatalf("Message = %q", page.Items[0].Message)
+	}
+	if !strings.Contains(page.Items[0].Source, "recorder_test.go:") {
+		t.Fatalf("Source = %q, want recorder_test.go:*", page.Items[0].Source)
+	}
+	if !strings.Contains(sink.String(), "test recorder message 42") {
+		t.Fatalf("stdout sink missing message: %q", sink.String())
+	}
+}
+
+func TestStoreListPaginatesNewestFirst(t *testing.T) {
+	t.Parallel()
+
+	store, err := NewStore(testmysql.NewDSN(t))
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	base := time.Date(2026, 4, 28, 13, 0, 0, 0, time.Local)
+	for index := 0; index < 3; index++ {
+		err := store.Append(Entry{
+			ID:        fmt.Sprintf("log_manual_%d", index),
+			Level:     "info",
+			Source:    fmt.Sprintf("source-%d", index),
+			Message:   fmt.Sprintf("message-%d", index),
+			Raw:       fmt.Sprintf("raw-%d", index),
+			CreatedAt: base.Add(time.Duration(index) * time.Second),
+		})
+		if err != nil {
+			t.Fatalf("Append() error = %v", err)
+		}
+	}
+
+	page, err := store.List(ListQuery{Page: 2, PageSize: 2})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if page.Total != 3 {
+		t.Fatalf("Total = %d, want 3", page.Total)
+	}
+	if len(page.Items) != 1 {
+		t.Fatalf("len(Items) = %d, want 1", len(page.Items))
+	}
+	if page.Items[0].Message != "message-0" {
+		t.Fatalf("Message = %q, want message-0", page.Items[0].Message)
+	}
+	if page.HasMore {
+		t.Fatal("HasMore = true, want false")
+	}
+}

--- a/internal/logs/store.go
+++ b/internal/logs/store.go
@@ -1,0 +1,122 @@
+package logs
+
+import (
+	"database/sql"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/luoliwoshang/open-xiaoai-agent/internal/storage"
+)
+
+type Store struct {
+	db  *sql.DB
+	seq uint64
+}
+
+func NewStore(dsn string) (*Store, error) {
+	db, err := storage.OpenRuntimeDB(dsn)
+	if err != nil {
+		return nil, err
+	}
+	return &Store{db: db}, nil
+}
+
+func (s *Store) Append(entry Entry) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+
+	entry.Level = normalizeLevel(entry.Level)
+	entry.Source = normalizeField(entry.Source)
+	entry.Message = normalizeField(entry.Message)
+	entry.Raw = normalizeField(entry.Raw)
+	if entry.CreatedAt.IsZero() {
+		entry.CreatedAt = time.Now()
+	}
+	if entry.ID == "" {
+		entry.ID = s.nextID()
+	}
+
+	if _, err := s.db.Exec(
+		`INSERT INTO runtime_logs (id, level, source, message, raw, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		entry.ID,
+		entry.Level,
+		entry.Source,
+		entry.Message,
+		entry.Raw,
+		storage.UnixMillis(entry.CreatedAt),
+	); err != nil {
+		return fmt.Errorf("insert runtime log: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) List(query ListQuery) (ListPage, error) {
+	query, err := NormalizeQuery(query)
+	if err != nil {
+		return ListPage{}, err
+	}
+	if s == nil || s.db == nil {
+		return ListPage{Page: query.Page, PageSize: query.PageSize}, nil
+	}
+
+	var total int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM runtime_logs`).Scan(&total); err != nil {
+		return ListPage{}, fmt.Errorf("count runtime logs: %w", err)
+	}
+
+	rows, err := s.db.Query(
+		`SELECT id, level, source, message, raw, created_at
+		FROM runtime_logs
+		ORDER BY created_at DESC, id DESC
+		LIMIT ? OFFSET ?`,
+		query.PageSize,
+		(query.Page-1)*query.PageSize,
+	)
+	if err != nil {
+		return ListPage{}, fmt.Errorf("query runtime logs: %w", err)
+	}
+	defer rows.Close()
+
+	page := ListPage{
+		Page:     query.Page,
+		PageSize: query.PageSize,
+		Total:    total,
+	}
+	for rows.Next() {
+		var item Entry
+		var createdAt int64
+		if err := rows.Scan(&item.ID, &item.Level, &item.Source, &item.Message, &item.Raw, &createdAt); err != nil {
+			return ListPage{}, fmt.Errorf("scan runtime log row: %w", err)
+		}
+		item.CreatedAt = storage.TimeFromUnixMillis(createdAt)
+		page.Items = append(page.Items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return ListPage{}, fmt.Errorf("iterate runtime log rows: %w", err)
+	}
+	page.HasMore = query.Page*query.PageSize < total
+	return page, nil
+}
+
+func (s *Store) Reset() error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	if _, err := s.db.Exec(`DELETE FROM runtime_logs`); err != nil {
+		return fmt.Errorf("reset runtime logs: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) nextID() string {
+	return fmt.Sprintf("log_%d_%d", time.Now().UnixMilli(), atomic.AddUint64(&s.seq, 1))
+}
+
+func normalizeField(value string) string {
+	if value == "" {
+		return ""
+	}
+	return value
+}

--- a/internal/storage/mysql.go
+++ b/internal/storage/mysql.go
@@ -170,6 +170,15 @@ func ensureSchema(db *sql.DB) error {
 			message LONGTEXT NOT NULL,
 			created_at BIGINT NOT NULL
 		)`,
+		`CREATE TABLE IF NOT EXISTS runtime_logs (
+			id VARCHAR(255) PRIMARY KEY,
+			level VARCHAR(32) NOT NULL,
+			source VARCHAR(255) NOT NULL,
+			message LONGTEXT NOT NULL,
+			raw LONGTEXT NOT NULL,
+			created_at BIGINT NOT NULL,
+			INDEX idx_runtime_logs_created_at (created_at)
+		)`,
 	}
 
 	for _, statement := range statements {

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/dashboard"
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/im"
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/llm"
+	runtimelogs "github.com/luoliwoshang/open-xiaoai-agent/internal/logs"
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/plugin"
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/plugins"
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/plugins/complextask"
@@ -44,6 +45,12 @@ func main() {
 		log.Fatal(err)
 	}
 	dsn := appConfig.Database.DSN
+	logStore, err := runtimelogs.NewStore(dsn)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.SetFlags(log.LstdFlags | log.Lmicroseconds | log.Lshortfile)
+	log.SetOutput(runtimelogs.NewRecorder(logStore, os.Stderr))
 	log.Printf("loaded SOUL.md (%d chars)", len(appConfig.Soul))
 	log.Printf("loaded models: intent=%s reply=%s", appConfig.Intent.Model, appConfig.Reply.Model)
 	llmClient := llm.NewClient()
@@ -97,7 +104,7 @@ func main() {
 
 	srv := server.New(cfg, asrService.OnASR)
 	go func() {
-		if err := dashboard.New(*dashboardAddr, taskManager, complexTaskService, asrService, settingsStore, imService).ListenAndServe(); err != nil {
+		if err := dashboard.New(*dashboardAddr, taskManager, complexTaskService, asrService, settingsStore, imService, logStore).ListenAndServe(); err != nil {
 			log.Printf("dashboard stopped: %v", err)
 		}
 	}()

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,11 +2,12 @@ import { AppTopbar } from './components/AppTopbar'
 import { useDashboardState } from './hooks/useDashboardState'
 import { useHashPage } from './hooks/useHashPage'
 import { DashboardPage } from './pages/DashboardPage'
+import { LogsPage } from './pages/LogsPage'
 import { SettingsPage } from './pages/SettingsPage'
 
 export default function App() {
   const page = useHashPage()
-  const { data, setData, loading, error, refresh } = useDashboardState()
+  const { data, setData, loading, error, refresh } = useDashboardState(page !== 'logs')
 
   return (
     <div className="app-shell">
@@ -22,6 +23,8 @@ export default function App() {
           loading={loading}
           setData={setData}
         />
+      ) : page === 'logs' ? (
+        <LogsPage />
       ) : (
         <SettingsPage
           data={data}
@@ -33,4 +36,3 @@ export default function App() {
     </div>
   )
 }
-

--- a/web/src/components/AppTopbar.tsx
+++ b/web/src/components/AppTopbar.tsx
@@ -19,6 +19,9 @@ export function AppTopbar({ page }: Props) {
         <a className={`topbar-link ${page === 'settings' ? 'topbar-link-active' : ''}`} href="#/settings">
           系统设置
         </a>
+        <a className={`topbar-link ${page === 'logs' ? 'topbar-link-active' : ''}`} href="#/logs">
+          后端日志
+        </a>
       </nav>
     </header>
   )

--- a/web/src/hooks/useDashboardState.ts
+++ b/web/src/hooks/useDashboardState.ts
@@ -3,12 +3,16 @@ import type { DashboardState } from '../types'
 import { fetchState } from '../lib/api'
 import { emptyState } from '../lib/dashboard'
 
-export function useDashboardState() {
+export function useDashboardState(enabled = true) {
   const [data, setData] = useState<DashboardState>(emptyState)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
+    if (!enabled) {
+      return
+    }
+
     let active = true
 
     async function refreshWithGuard() {
@@ -36,7 +40,7 @@ export function useDashboardState() {
       active = false
       window.clearInterval(timer)
     }
-  }, [])
+  }, [enabled])
 
   async function refresh() {
     const next = await fetchState()
@@ -53,4 +57,3 @@ export function useDashboardState() {
     refresh,
   }
 }
-

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { DashboardState } from '../types'
+import type { DashboardState, LogPage } from '../types'
 import { normalizeState } from './dashboard'
 
 export async function fetchState() {
@@ -33,4 +33,16 @@ export async function postFormData<T>(url: string, payload: FormData) {
     throw new Error(await response.text())
   }
   return (await response.json()) as T
+}
+
+export async function fetchLogsPage(page: number, pageSize: number) {
+  const params = new URLSearchParams({
+    page: String(page),
+    page_size: String(pageSize),
+  })
+  const response = await fetch(`/api/logs?${params.toString()}`, { cache: 'no-store' })
+  if (!response.ok) {
+    throw new Error(await response.text())
+  }
+  return (await response.json()) as LogPage
 }

--- a/web/src/lib/dashboard.ts
+++ b/web/src/lib/dashboard.ts
@@ -6,7 +6,7 @@ import type {
   TaskState,
 } from '../types'
 
-export type Page = 'dashboard' | 'settings'
+export type Page = 'dashboard' | 'settings' | 'logs'
 
 export const emptyState: DashboardState = {
   tasks: [],
@@ -56,7 +56,14 @@ export function latest<T extends { created_at?: string; updated_at?: string }>(i
 }
 
 export function currentPageFromHash(): Page {
-  return window.location.hash === '#/settings' ? 'settings' : 'dashboard'
+  switch (window.location.hash) {
+    case '#/settings':
+      return 'settings'
+    case '#/logs':
+      return 'logs'
+    default:
+      return 'dashboard'
+  }
 }
 
 export function selectBestTarget(targets: IMTarget[], accountID: string) {
@@ -90,4 +97,3 @@ export function normalizeSettings(raw: Partial<SettingsSnapshot> | undefined): S
     im_selected_target_id: raw?.im_selected_target_id ?? '',
   }
 }
-

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useMemo, useState } from 'react'
+import { fetchLogsPage } from '../lib/api'
+import { formatTime } from '../lib/dashboard'
+import type { LogEntry, LogPage } from '../types'
+
+const emptyLogPage: LogPage = {
+  items: [],
+  page: 1,
+  page_size: 50,
+  total: 0,
+  has_more: false,
+}
+
+const levelLabels: Record<LogEntry['level'], string> = {
+  debug: '调试',
+  info: '信息',
+  warn: '警告',
+  error: '错误',
+  fatal: '致命',
+}
+
+export function LogsPage() {
+  const [page, setPage] = useState(1)
+  const [pageSize, setPageSize] = useState(50)
+  const [data, setData] = useState<LogPage>(emptyLogPage)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let active = true
+
+    async function refresh() {
+      try {
+        const next = await fetchLogsPage(page, pageSize)
+        if (!active) return
+        setData(next)
+        setError(null)
+      } catch (err) {
+        if (!active) return
+        setError(err instanceof Error ? err.message : '日志加载失败')
+      } finally {
+        if (active) {
+          setLoading(false)
+        }
+      }
+    }
+
+    void refresh()
+    if (page !== 1) {
+      return () => {
+        active = false
+      }
+    }
+
+    const timer = window.setInterval(() => {
+      void refresh()
+    }, 2000)
+    return () => {
+      active = false
+      window.clearInterval(timer)
+    }
+  }, [page, pageSize])
+
+  const pageCount = useMemo(() => {
+    if (data.total === 0) return 1
+    return Math.max(1, Math.ceil(data.total / data.page_size))
+  }, [data.page_size, data.total])
+
+  const latestLog = data.items[0] ?? null
+
+  async function refreshNow() {
+    try {
+      setLoading(true)
+      const next = await fetchLogsPage(page, pageSize)
+      setData(next)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '日志加载失败')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <main className="logs-page">
+      <section className="settings-hero-card logs-hero-card">
+        <div>
+          <p className="eyebrow">BACKEND LOGS</p>
+          <h2>后端日志中心</h2>
+          <p className="hero-text">
+            这里只看 Go server 的运行日志。日志会带上时间、源文件和原始消息，适合直接把当前页交给 AI 辅助排查。
+          </p>
+        </div>
+        <div className="settings-hero-stats">
+          <div className="metric-card metric-cyan">
+            <span>总日志数</span>
+            <strong>{data.total}</strong>
+          </div>
+          <div className="metric-card metric-amber">
+            <span>当前分页</span>
+            <strong>
+              {data.page} / {pageCount}
+            </strong>
+          </div>
+          <div className="metric-card metric-mint">
+            <span>最新来源</span>
+            <strong>{latestLog?.source || '—'}</strong>
+          </div>
+        </div>
+      </section>
+
+      <section className="panel logs-toolbar">
+        <div className="panel-head compact">
+          <div>
+            <p className="eyebrow">LOG CONTROLS</p>
+            <h3>分页浏览</h3>
+          </div>
+        </div>
+
+        <div className="settings-actions">
+          <label className="settings-field logs-size-field">
+            <span>每页条数</span>
+            <select
+              className="settings-select"
+              value={pageSize}
+              onChange={(event) => {
+                setPageSize(Number(event.target.value))
+                setPage(1)
+              }}
+            >
+              <option value={20}>20</option>
+              <option value={50}>50</option>
+              <option value={100}>100</option>
+            </select>
+          </label>
+
+          <button className="ghost-button" disabled={loading} onClick={() => void refreshNow()} type="button">
+            {loading ? '加载中...' : '刷新当前页'}
+          </button>
+
+          <span className="settings-note">
+            第 1 页会自动刷新，其它页保持静态，避免你翻页排障时被新日志打断。
+          </span>
+        </div>
+
+        <div className="settings-actions">
+          <button className="ghost-button" disabled={page <= 1 || loading} onClick={() => setPage((current) => current - 1)} type="button">
+            上一页
+          </button>
+          <button
+            className="ghost-button"
+            disabled={!data.has_more || loading}
+            onClick={() => setPage((current) => current + 1)}
+            type="button"
+          >
+            下一页
+          </button>
+          <span className="panel-meta">
+            {loading ? '正在加载日志...' : `本页 ${data.items.length} 条`}
+          </span>
+        </div>
+      </section>
+
+      {error ? <div className="error-banner logs-error-banner">日志接口异常：{error}</div> : null}
+
+      <section className="logs-list">
+        {data.items.length === 0 ? (
+          <article className="panel empty-card">当前还没有后端日志。</article>
+        ) : (
+          data.items.map((item) => (
+            <article className="panel log-card" key={item.id}>
+              <div className="log-card-head">
+                <div className="settings-actions">
+                  <span className={`badge badge-log badge-log-${item.level}`}>{levelLabels[item.level]}</span>
+                  <span className="panel-meta">{formatTime(item.created_at)}</span>
+                </div>
+                <code className="log-source">{item.source || 'unknown'}</code>
+              </div>
+
+              <div className="task-meta">
+                <span>消息正文</span>
+                <p className="log-message">{item.message || '—'}</p>
+              </div>
+
+              <div className="task-meta task-meta-wide">
+                <span>原始日志</span>
+                <pre className="log-raw">{item.raw}</pre>
+              </div>
+            </article>
+          ))
+        )}
+      </section>
+    </main>
+  )
+}

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -163,31 +163,31 @@ export function LogsPage() {
 
       {error ? <div className="error-banner logs-error-banner">日志接口异常：{error}</div> : null}
 
-      <section className="logs-list">
+      <section className="panel logs-stream">
+        <div className="panel-head compact">
+          <div>
+            <p className="eyebrow">LOG STREAM</p>
+            <h3>紧凑日志流</h3>
+          </div>
+          <span className="panel-meta">按时间倒序展示，适合连续排查。</span>
+        </div>
+
         {data.items.length === 0 ? (
-          <article className="panel empty-card">当前还没有后端日志。</article>
+          <div className="empty-card">当前还没有后端日志。</div>
         ) : (
-          data.items.map((item) => (
-            <article className="panel log-card" key={item.id}>
-              <div className="log-card-head">
-                <div className="settings-actions">
+          <div className="logs-stream-list">
+            {data.items.map((item) => (
+              <article className="log-row" key={item.id}>
+                <div className="log-row-primary">
                   <span className={`badge badge-log badge-log-${item.level}`}>{levelLabels[item.level]}</span>
                   <span className="panel-meta">{formatTime(item.created_at)}</span>
+                  <code className="log-source">{item.source || 'unknown'}</code>
                 </div>
-                <code className="log-source">{item.source || 'unknown'}</code>
-              </div>
-
-              <div className="task-meta">
-                <span>消息正文</span>
-                <p className="log-message">{item.message || '—'}</p>
-              </div>
-
-              <div className="task-meta task-meta-wide">
-                <span>原始日志</span>
-                <pre className="log-raw">{item.raw}</pre>
-              </div>
-            </article>
-          ))
+                <p className="log-row-message">{item.message || '—'}</p>
+                <code className="log-row-raw">{item.raw}</code>
+              </article>
+            ))}
+          </div>
         )}
       </section>
     </main>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -966,16 +966,32 @@ code {
   gap: 14px;
 }
 
-.log-card {
+.logs-stream {
   display: grid;
   gap: 16px;
 }
 
-.log-card-head {
+.logs-stream-list {
+  display: grid;
+  gap: 0;
+}
+
+.log-row {
+  display: grid;
+  gap: 8px;
+  padding: 14px 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.log-row:first-child {
+  border-top: 0;
+}
+
+.log-row-primary {
   display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 16px;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
 .log-source {
@@ -983,21 +999,21 @@ code {
   word-break: break-all;
 }
 
-.log-message {
+.log-row-message {
+  margin: 0;
   white-space: pre-wrap;
   word-break: break-word;
+  color: rgba(237, 242, 255, 0.88);
+  line-height: 1.55;
 }
 
-.log-raw {
-  margin: 0;
-  padding: 14px 16px;
-  border-radius: 16px;
-  background: rgba(5, 11, 20, 0.86);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  color: rgba(237, 242, 255, 0.78);
-  font: inherit;
+.log-row-raw {
+  display: block;
+  color: rgba(237, 242, 255, 0.46);
+  font-size: 0.84rem;
   white-space: pre-wrap;
   word-break: break-word;
+  line-height: 1.5;
 }
 
 .logs-error-banner {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -397,6 +397,26 @@ code {
   border-color: rgba(166, 135, 255, 0.28);
 }
 
+.badge-log-debug,
+.badge-log-info {
+  color: #93fff3;
+  background: rgba(42, 234, 196, 0.14);
+  border-color: rgba(42, 234, 196, 0.32);
+}
+
+.badge-log-warn {
+  color: #ffe7a6;
+  background: rgba(255, 190, 92, 0.14);
+  border-color: rgba(255, 190, 92, 0.32);
+}
+
+.badge-log-error,
+.badge-log-fatal {
+  color: #ffb0c8;
+  background: rgba(255, 112, 162, 0.14);
+  border-color: rgba(255, 112, 162, 0.28);
+}
+
 .timeline-item {
   position: relative;
   display: grid;
@@ -918,6 +938,71 @@ code {
   align-items: center;
   gap: 10px;
   flex-wrap: wrap;
+}
+
+.logs-page {
+  position: relative;
+  margin: 0 auto;
+  max-width: 1360px;
+  display: grid;
+  gap: 20px;
+}
+
+.logs-hero-card {
+  margin-bottom: 0;
+}
+
+.logs-toolbar {
+  display: grid;
+  gap: 16px;
+}
+
+.logs-size-field {
+  min-width: 140px;
+}
+
+.logs-list {
+  display: grid;
+  gap: 14px;
+}
+
+.log-card {
+  display: grid;
+  gap: 16px;
+}
+
+.log-card-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.log-source {
+  color: rgba(237, 242, 255, 0.76);
+  word-break: break-all;
+}
+
+.log-message {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.log-raw {
+  margin: 0;
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: rgba(5, 11, 20, 0.86);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: rgba(237, 242, 255, 0.78);
+  font: inherit;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.logs-error-banner {
+  margin: 0 auto;
+  max-width: 1360px;
 }
 
 .insight-card h3 {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -134,3 +134,20 @@ export type WeChatLoginStatus = {
   message: string
   candidate?: WeChatLoginCandidate
 }
+
+export type LogEntry = {
+  id: string
+  level: 'debug' | 'info' | 'warn' | 'error' | 'fatal'
+  source: string
+  message: string
+  raw: string
+  created_at: string
+}
+
+export type LogPage = {
+  items: LogEntry[]
+  page: number
+  page_size: number
+  total: number
+  has_more: boolean
+}


### PR DESCRIPTION
## 背景
- 当前后端已有大量 `log.Printf` 输出，但只能在控制台里看
- 远程排障时不方便结合管理界面和 AI 一起定位问题
- 日志数据也不适合继续塞进 `/api/state`

## 变更
- 新增 `internal/logs`，接管标准 logger 并将后端日志持久化到 MySQL
- 新增 `runtime_logs` 表，保存时间、级别、来源、消息正文和原始日志行
- 新增 `GET /api/logs` 分页接口，独立于 `/api/state`
- 管理界面新增“后端日志”页面，支持分页浏览、每页条数切换和第一页自动刷新
- 同步更新 README 与 AGENTS，补充日志系统说明

## 验证
- `GOCACHE=$(pwd)/.gocache go test ./...`
- `npm run build:web`

Closes #16