### PR TITLE
fix: 对齐官方实现修复微信图片投递

### DIFF
--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -348,7 +348,7 @@ func (s *Service) MirrorText(text string) {
 	default:
 		log.Printf("im mirror queue is full, dropping message")
 		_ = s.store.MarkDeliveryFailure(request.AccountID, "IM 镜像发送队列繁忙，本次消息已丢弃")
-		_ = s.store.AppendEvent(request.AccountID, "send_drop", "IM 镜像发送队列繁忙，本次消息已丢弃")
+		s.appendEvent(request.AccountID, "send_drop", "IM 镜像发送队列繁忙，本次消息已丢弃")
 	}
 }
 
@@ -372,12 +372,12 @@ func (s *Service) deliverText(request deliveryRequest) (DeliveryReceipt, error) 
 	result, err := adapter.SendText(ctx, account, target, request.Text)
 	if err != nil {
 		_ = s.store.MarkDeliveryFailure(account.ID, err.Error())
-		_ = s.store.AppendEvent(account.ID, "send_failed", fmt.Sprintf("发送到 %s 失败：%s", target.Name, err.Error()))
+		s.appendEvent(account.ID, "send_failed", fmt.Sprintf("发送到 %s 失败：%s", target.Name, err.Error()))
 		return DeliveryReceipt{}, err
 	}
 
 	_ = s.store.MarkDeliverySuccess(account.ID)
-	_ = s.store.AppendEvent(account.ID, "send", fmt.Sprintf("已发送到 %s：%s", target.Name, trimForEvent(request.Text)))
+	s.appendEvent(account.ID, "send", fmt.Sprintf("已发送到 %s：%s", target.Name, trimForEvent(request.Text)))
 	return DeliveryReceipt{
 		Account:   account,
 		Target:    target,
@@ -393,13 +393,16 @@ func (s *Service) deliverImage(accountID string, targetID string, image Prepared
 		return DeliveryReceipt{}, err
 	}
 
+	log.Printf("im image delivery started: account=%s target=%s platform=%s file=%q mime=%s size=%d caption_len=%d", account.ID, target.ID, account.Platform, image.FileName, image.MimeType, image.Size, len(strings.TrimSpace(caption)))
+
 	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 	defer cancel()
 
 	result, err := adapter.SendImage(ctx, account, target, image, caption)
 	if err != nil {
 		_ = s.store.MarkDeliveryFailure(account.ID, err.Error())
-		_ = s.store.AppendEvent(account.ID, "send_failed", fmt.Sprintf("发送图片到 %s 失败：%s", target.Name, err.Error()))
+		s.appendEvent(account.ID, "send_failed", fmt.Sprintf("发送图片到 %s 失败：%s", target.Name, err.Error()))
+		log.Printf("im image delivery failed: account=%s target=%s platform=%s file=%q err=%v", account.ID, target.ID, account.Platform, image.FileName, err)
 		return DeliveryReceipt{}, err
 	}
 
@@ -408,7 +411,8 @@ func (s *Service) deliverImage(accountID string, targetID string, image Prepared
 	if eventLabel == "" {
 		eventLabel = image.FileName
 	}
-	_ = s.store.AppendEvent(account.ID, "send_image", fmt.Sprintf("已发送图片到 %s：%s", target.Name, trimForEvent(eventLabel)))
+	s.appendEvent(account.ID, "send_image", fmt.Sprintf("已发送图片到 %s：%s", target.Name, trimForEvent(eventLabel)))
+	log.Printf("im image delivery succeeded: account=%s target=%s platform=%s file=%q message_id=%s", account.ID, target.ID, account.Platform, image.FileName, result.MessageID)
 	return DeliveryReceipt{
 		Account:       account,
 		Target:        target,
@@ -418,6 +422,15 @@ func (s *Service) deliverImage(accountID string, targetID string, image Prepared
 		MediaFileName: image.FileName,
 		MediaMimeType: image.MimeType,
 	}, nil
+}
+
+func (s *Service) appendEvent(accountID string, eventType string, message string) {
+	if s == nil || s.store == nil {
+		return
+	}
+	if err := s.store.AppendEvent(accountID, eventType, message); err != nil {
+		log.Printf("append im event failed: account=%s type=%s err=%v", accountID, eventType, err)
+	}
 }
 
 func (s *Service) resolveDelivery(accountID string, targetID string) (Account, Target, Adapter, error) {

--- a/internal/im/store.go
+++ b/internal/im/store.go
@@ -600,5 +600,5 @@ func scanTarget(scanner interface {
 
 func (s *Store) nextID(prefix string) string {
 	value := atomic.AddUint64(&s.seq, 1)
-	return fmt.Sprintf("%s_%d", prefix, value)
+	return fmt.Sprintf("%s_%d_%d", prefix, time.Now().UnixNano(), value)
 }

--- a/internal/im/wechat_adapter.go
+++ b/internal/im/wechat_adapter.go
@@ -30,7 +30,8 @@ const (
 )
 
 type WeChatAdapter struct {
-	client *http.Client
+	client     *http.Client
+	cdnBaseURL string
 
 	mu     sync.Mutex
 	logins map[string]*activeWeChatLogin
@@ -60,8 +61,9 @@ type weChatQRStatusResponse struct {
 
 func NewWeChatAdapter() *WeChatAdapter {
 	return &WeChatAdapter{
-		client: &http.Client{Timeout: weChatDefaultRequestTTL},
-		logins: make(map[string]*activeWeChatLogin),
+		client:     &http.Client{Timeout: weChatDefaultRequestTTL},
+		cdnBaseURL: weChatDefaultCDNBaseURL,
+		logins:     make(map[string]*activeWeChatLogin),
 	}
 }
 

--- a/internal/im/wechat_image.go
+++ b/internal/im/wechat_image.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -20,19 +21,26 @@ import (
 const weChatDefaultCDNBaseURL = "https://novac2c.cdn.weixin.qq.com/c2c"
 
 type weChatGetUploadURLResponse struct {
-	UploadParam    string `json:"upload_param"`
-	ThumbUploadURL string `json:"thumb_upload_param"`
-	UploadFullURL  string `json:"upload_full_url"`
+	UploadParam      string `json:"upload_param"`
+	ThumbUploadParam string `json:"thumb_upload_param"`
+	UploadFullURL    string `json:"upload_full_url"`
+}
+
+type weChatUploadedMedia struct {
+	DownloadEncryptedParam string
+	CiphertextBytes        int64
 }
 
 type weChatUploadedImage struct {
-	FileKey                 string
-	DownloadEncryptedParam  string
-	AESKeyRaw               []byte
-	FileSizeCiphertextBytes int64
+	FileKey   string
+	AESKeyRaw []byte
+	AESKeyHex string
+	Original  weChatUploadedMedia
 }
 
 func (a *WeChatAdapter) SendImage(ctx context.Context, account Account, target Target, image PreparedImage, caption string) (ImageSendResult, error) {
+	log.Printf("im wechat send image start: account=%s target=%s file=%q mime=%s size=%d caption_len=%d", account.ID, target.ID, image.FileName, image.MimeType, image.Size, len(strings.TrimSpace(caption)))
+
 	if strings.TrimSpace(caption) != "" {
 		if _, err := a.SendText(ctx, account, target, caption); err != nil {
 			return ImageSendResult{}, err
@@ -49,6 +57,15 @@ func (a *WeChatAdapter) SendImage(ctx context.Context, account Account, target T
 		return ImageSendResult{}, err
 	}
 
+	imageItem := map[string]any{
+		"media": map[string]any{
+			"encrypt_query_param": uploaded.Original.DownloadEncryptedParam,
+			"aes_key":             base64.StdEncoding.EncodeToString([]byte(uploaded.AESKeyHex)),
+			"encrypt_type":        1,
+		},
+		"mid_size": uploaded.Original.CiphertextBytes,
+	}
+
 	body, err := json.Marshal(map[string]any{
 		"msg": map[string]any{
 			"from_user_id":  "",
@@ -58,15 +75,8 @@ func (a *WeChatAdapter) SendImage(ctx context.Context, account Account, target T
 			"message_state": 2,
 			"item_list": []map[string]any{
 				{
-					"type": 2,
-					"image_item": map[string]any{
-						"media": map[string]any{
-							"encrypt_query_param": uploaded.DownloadEncryptedParam,
-							"aes_key":             base64.StdEncoding.EncodeToString(uploaded.AESKeyRaw),
-							"encrypt_type":        1,
-						},
-						"mid_size": uploaded.FileSizeCiphertextBytes,
-					},
+					"type":       2,
+					"image_item": imageItem,
 				},
 			},
 		},
@@ -81,6 +91,7 @@ func (a *WeChatAdapter) SendImage(ctx context.Context, account Account, target T
 	if _, err := a.postJSON(ctx, account.BaseURL, "ilink/bot/sendmessage", account.Token, body); err != nil {
 		return ImageSendResult{}, err
 	}
+	log.Printf("im wechat send image succeeded: account=%s target=%s file=%q message_id=%s official_payload=true", account.ID, target.ID, image.FileName, clientID)
 	return ImageSendResult{MessageID: clientID}, nil
 }
 
@@ -89,7 +100,6 @@ func (a *WeChatAdapter) uploadImage(ctx context.Context, account Account, target
 	if err != nil {
 		return weChatUploadedImage{}, fmt.Errorf("read image file: %w", err)
 	}
-
 	fileKey, err := randomWeChatToken(16)
 	if err != nil {
 		return weChatUploadedImage{}, err
@@ -99,31 +109,41 @@ func (a *WeChatAdapter) uploadImage(ctx context.Context, account Account, target
 		return weChatUploadedImage{}, fmt.Errorf("generate image aes key: %w", err)
 	}
 
-	rawSize := len(content)
 	rawMD5 := md5.Sum(content)
 	ciphertext, err := encryptWeChatAESECB(content, aesKeyRaw)
 	if err != nil {
 		return weChatUploadedImage{}, err
 	}
 
-	uploadMeta, err := a.getUploadURL(ctx, account, target, fileKey, rawSize, hex.EncodeToString(rawMD5[:]), len(ciphertext), hex.EncodeToString(aesKeyRaw))
+	log.Printf("im wechat image upload start: account=%s target=%s file=%q raw_bytes=%d", account.ID, target.ID, image.FileName, len(content))
+
+	aesKeyHex := hex.EncodeToString(aesKeyRaw)
+	uploadMeta, err := a.getUploadURL(ctx, account, target, fileKey, len(content), hex.EncodeToString(rawMD5[:]), len(ciphertext), aesKeyHex)
 	if err != nil {
 		return weChatUploadedImage{}, err
 	}
-	downloadParam, err := a.uploadImageCiphertext(ctx, uploadMeta, fileKey, ciphertext)
+	log.Printf("im wechat image upload url ready: account=%s target=%s file_key=%s official_flow=true", account.ID, target.ID, fileKey)
+
+	downloadParam, err := a.uploadImageCiphertext(ctx, uploadMeta.UploadFullURL, uploadMeta.UploadParam, fileKey, ciphertext, "image")
 	if err != nil {
 		return weChatUploadedImage{}, err
 	}
+	log.Printf("im wechat image upload succeeded: account=%s target=%s file=%q file_key=%s encrypted_bytes=%d official_flow=true", account.ID, target.ID, image.FileName, fileKey, len(ciphertext))
 
 	return weChatUploadedImage{
-		FileKey:                 fileKey,
-		DownloadEncryptedParam:  downloadParam,
-		AESKeyRaw:               aesKeyRaw,
-		FileSizeCiphertextBytes: int64(len(ciphertext)),
+		FileKey:   fileKey,
+		AESKeyRaw: aesKeyRaw,
+		AESKeyHex: aesKeyHex,
+		Original: weChatUploadedMedia{
+			DownloadEncryptedParam: downloadParam,
+			CiphertextBytes:        int64(len(ciphertext)),
+		},
 	}, nil
 }
 
 func (a *WeChatAdapter) getUploadURL(ctx context.Context, account Account, target Target, fileKey string, rawSize int, rawMD5 string, cipherSize int, aesKeyHex string) (weChatGetUploadURLResponse, error) {
+	log.Printf("im wechat image upload url request: account=%s target=%s file_key=%s raw_bytes=%d encrypted_bytes=%d official_flow=true", account.ID, target.ID, fileKey, rawSize, cipherSize)
+
 	body, err := json.Marshal(map[string]any{
 		"filekey":       fileKey,
 		"media_type":    1,
@@ -156,11 +176,12 @@ func (a *WeChatAdapter) getUploadURL(ctx context.Context, account Account, targe
 	return resp, nil
 }
 
-func (a *WeChatAdapter) uploadImageCiphertext(ctx context.Context, uploadMeta weChatGetUploadURLResponse, fileKey string, ciphertext []byte) (string, error) {
-	uploadURL := strings.TrimSpace(uploadMeta.UploadFullURL)
+func (a *WeChatAdapter) uploadImageCiphertext(ctx context.Context, uploadFullURL string, uploadParam string, fileKey string, ciphertext []byte, label string) (string, error) {
+	uploadURL := strings.TrimSpace(uploadFullURL)
 	if uploadURL == "" {
-		uploadURL = buildWeChatCDNUploadURL(strings.TrimSpace(uploadMeta.UploadParam), fileKey)
+		uploadURL = buildWeChatCDNUploadURL(a.cdnBaseURL, strings.TrimSpace(uploadParam), fileKey)
 	}
+	log.Printf("im wechat cdn upload start: kind=%s file_key=%s bytes=%d host=%s", label, fileKey, len(ciphertext), mustWeChatHost(uploadURL))
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadURL, bytes.NewReader(ciphertext))
 	if err != nil {
 		return "", fmt.Errorf("build wechat cdn upload request: %w", err)
@@ -189,11 +210,24 @@ func (a *WeChatAdapter) uploadImageCiphertext(ctx context.Context, uploadMeta we
 	if downloadParam == "" {
 		return "", fmt.Errorf("wechat cdn upload response is missing x-encrypted-param")
 	}
+	log.Printf("im wechat cdn upload succeeded: kind=%s file_key=%s", label, fileKey)
 	return downloadParam, nil
 }
 
-func buildWeChatCDNUploadURL(uploadParam string, fileKey string) string {
-	return fmt.Sprintf("%s/upload?encrypted_query_param=%s&filekey=%s", weChatDefaultCDNBaseURL, url.QueryEscape(uploadParam), url.QueryEscape(fileKey))
+func buildWeChatCDNUploadURL(baseURL string, uploadParam string, fileKey string) string {
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if baseURL == "" {
+		baseURL = weChatDefaultCDNBaseURL
+	}
+	return fmt.Sprintf("%s/upload?encrypted_query_param=%s&filekey=%s", baseURL, url.QueryEscape(uploadParam), url.QueryEscape(fileKey))
+}
+
+func mustWeChatHost(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	return parsed.Host
 }
 
 func encryptWeChatAESECB(plaintext []byte, key []byte) ([]byte, error) {

--- a/internal/im/wechat_image_test.go
+++ b/internal/im/wechat_image_test.go
@@ -1,0 +1,339 @@
+package im
+
+import (
+	"context"
+	"encoding/json"
+	"image"
+	"image/color"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestWeChatAdapterSendImageMatchesOfficialPayload(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu             sync.Mutex
+		handlerErr     error
+		getUploadReq   map[string]any
+		sendMessageReq map[string]any
+		uploadCounts   = make(map[string]int)
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/ilink/bot/getuploadurl":
+			defer r.Body.Close()
+			payload := make(map[string]any)
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				mu.Lock()
+				handlerErr = err
+				mu.Unlock()
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			getUploadReq = payload
+			mu.Unlock()
+			writeJSON(t, w, map[string]any{
+				"upload_param": "orig-param",
+			})
+		case "/cdn/upload":
+			kind := r.URL.Query().Get("encrypted_query_param")
+			mu.Lock()
+			uploadCounts[kind]++
+			mu.Unlock()
+			if kind == "" {
+				http.Error(w, "missing encrypted_query_param", http.StatusBadRequest)
+				mu.Lock()
+				handlerErr = errMissingQueryParam
+				mu.Unlock()
+				return
+			}
+			w.Header().Set("x-encrypted-param", "download-"+kind)
+			w.WriteHeader(http.StatusOK)
+		case "/ilink/bot/sendmessage":
+			defer r.Body.Close()
+			payload := make(map[string]any)
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				mu.Lock()
+				handlerErr = err
+				mu.Unlock()
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			sendMessageReq = payload
+			mu.Unlock()
+			writeJSON(t, w, map[string]any{})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	imagePath, imageBytes := writeTestPNG(t, 800, 600)
+	adapter := &WeChatAdapter{
+		client:     server.Client(),
+		cdnBaseURL: server.URL + "/cdn",
+		logins:     make(map[string]*activeWeChatLogin),
+	}
+
+	_, err := adapter.SendImage(context.Background(), Account{
+		ID:       "acc_1",
+		Platform: PlatformWeChat,
+		BaseURL:  server.URL,
+		Token:    "token",
+	}, Target{
+		ID:           "target_1",
+		AccountID:    "acc_1",
+		TargetUserID: "user@im.wechat",
+	}, PreparedImage{
+		FilePath: imagePath,
+		FileName: filepath.Base(imagePath),
+		MimeType: "image/png",
+		Size:     int64(len(imageBytes)),
+	}, "")
+	if err != nil {
+		t.Fatalf("SendImage() error = %v", err)
+	}
+	mu.Lock()
+	if handlerErr != nil {
+		t.Fatalf("handler error = %v", handlerErr)
+	}
+	mu.Unlock()
+
+	mu.Lock()
+	if getUploadReq == nil {
+		mu.Unlock()
+		t.Fatal("getuploadurl request was not captured")
+	}
+	if got := getUploadReq["no_need_thumb"].(bool); !got {
+		mu.Unlock()
+		t.Fatal("no_need_thumb = false, want true")
+	}
+	if _, ok := getUploadReq["thumb_rawsize"]; ok {
+		mu.Unlock()
+		t.Fatal("thumb_rawsize exists, want omitted")
+	}
+	if _, ok := getUploadReq["thumb_filesize"]; ok {
+		mu.Unlock()
+		t.Fatal("thumb_filesize exists, want omitted")
+	}
+	if _, ok := getUploadReq["thumb_rawfilemd5"]; ok {
+		mu.Unlock()
+		t.Fatal("thumb_rawfilemd5 exists, want omitted")
+	}
+
+	origUploads := uploadCounts["orig-param"]
+	if sendMessageReq == nil {
+		mu.Unlock()
+		t.Fatal("sendmessage request was not captured")
+	}
+	sendReq := sendMessageReq
+	mu.Unlock()
+	if origUploads != 1 {
+		t.Fatalf("orig upload count = %d, want 1", origUploads)
+	}
+
+	msg := sendReq["msg"].(map[string]any)
+	itemList := msg["item_list"].([]any)
+	if len(itemList) != 1 {
+		t.Fatalf("len(item_list) = %d, want 1", len(itemList))
+	}
+	imageItem := itemList[0].(map[string]any)["image_item"].(map[string]any)
+	if got := int(imageItem["mid_size"].(float64)); got <= 0 {
+		t.Fatalf("mid_size = %d, want > 0", got)
+	}
+	if _, ok := imageItem["thumb_media"]; ok {
+		t.Fatal("thumb_media exists, want omitted")
+	}
+	if _, ok := imageItem["thumb_size"]; ok {
+		t.Fatal("thumb_size exists, want omitted")
+	}
+	if _, ok := imageItem["thumb_width"]; ok {
+		t.Fatal("thumb_width exists, want omitted")
+	}
+	if _, ok := imageItem["thumb_height"]; ok {
+		t.Fatal("thumb_height exists, want omitted")
+	}
+	if _, ok := imageItem["aeskey"]; ok {
+		t.Fatal("image_item.aeskey exists, want omitted")
+	}
+
+	media := imageItem["media"].(map[string]any)
+	if got := media["encrypt_query_param"].(string); got != "download-orig-param" {
+		t.Fatalf("media.encrypt_query_param = %q, want %q", got, "download-orig-param")
+	}
+	if got := media["aes_key"].(string); got == "" {
+		t.Fatal("media.aes_key = empty, want encoded key")
+	}
+}
+
+func TestWeChatAdapterSendImageIgnoresThumbUploadParamWhenServerReturnsIt(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu             sync.Mutex
+		handlerErr     error
+		sendMessageReq map[string]any
+		uploadCounts   = make(map[string]int)
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/ilink/bot/getuploadurl":
+			writeJSON(t, w, map[string]any{
+				"upload_param":       "orig-param",
+				"thumb_upload_param": "thumb-param",
+			})
+		case "/cdn/upload":
+			kind := r.URL.Query().Get("encrypted_query_param")
+			mu.Lock()
+			uploadCounts[kind]++
+			mu.Unlock()
+			if kind == "" {
+				http.Error(w, "missing encrypted_query_param", http.StatusBadRequest)
+				mu.Lock()
+				handlerErr = errMissingQueryParam
+				mu.Unlock()
+				return
+			}
+			w.Header().Set("x-encrypted-param", "download-"+kind)
+			w.WriteHeader(http.StatusOK)
+		case "/ilink/bot/sendmessage":
+			defer r.Body.Close()
+			payload := make(map[string]any)
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				mu.Lock()
+				handlerErr = err
+				mu.Unlock()
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			sendMessageReq = payload
+			mu.Unlock()
+			writeJSON(t, w, map[string]any{})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	imagePath, imageBytes := writeTestPNG(t, 800, 600)
+	adapter := &WeChatAdapter{
+		client:     server.Client(),
+		cdnBaseURL: server.URL + "/cdn",
+		logins:     make(map[string]*activeWeChatLogin),
+	}
+
+	_, err := adapter.SendImage(context.Background(), Account{
+		ID:       "acc_1",
+		Platform: PlatformWeChat,
+		BaseURL:  server.URL,
+		Token:    "token",
+	}, Target{
+		ID:           "target_1",
+		AccountID:    "acc_1",
+		TargetUserID: "user@im.wechat",
+	}, PreparedImage{
+		FilePath: imagePath,
+		FileName: filepath.Base(imagePath),
+		MimeType: "image/png",
+		Size:     int64(len(imageBytes)),
+	}, "")
+	if err != nil {
+		t.Fatalf("SendImage() error = %v", err)
+	}
+
+	mu.Lock()
+	if handlerErr != nil {
+		mu.Unlock()
+		t.Fatalf("handler error = %v", handlerErr)
+	}
+	origUploads := uploadCounts["orig-param"]
+	if sendMessageReq == nil {
+		mu.Unlock()
+		t.Fatal("sendmessage request was not captured")
+	}
+	sendReq := sendMessageReq
+	mu.Unlock()
+
+	if origUploads != 1 {
+		t.Fatalf("orig upload count = %d, want 1", origUploads)
+	}
+	if got := uploadCounts["thumb-param"]; got != 0 {
+		t.Fatalf("thumb upload count = %d, want 0", got)
+	}
+	msg := sendReq["msg"].(map[string]any)
+	itemList := msg["item_list"].([]any)
+	imageItem := itemList[0].(map[string]any)["image_item"].(map[string]any)
+	if _, ok := imageItem["thumb_media"]; ok {
+		t.Fatal("thumb_media exists, want omitted in official payload")
+	}
+	if _, ok := imageItem["thumb_size"]; ok {
+		t.Fatal("thumb_size exists, want omitted in official payload")
+	}
+	if _, ok := imageItem["thumb_width"]; ok {
+		t.Fatal("thumb_width exists, want omitted in official payload")
+	}
+	if _, ok := imageItem["thumb_height"]; ok {
+		t.Fatal("thumb_height exists, want omitted in official payload")
+	}
+}
+
+var errMissingQueryParam = &requestError{message: "missing encrypted_query_param"}
+
+type requestError struct {
+	message string
+}
+
+func (e *requestError) Error() string {
+	return e.message
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, payload map[string]any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		t.Fatalf("encode json response: %v", err)
+	}
+}
+
+func writeTestPNG(t *testing.T, width int, height int) (string, []byte) {
+	t.Helper()
+
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			img.Set(x, y, color.RGBA{
+				R: uint8((x * 255) / width),
+				G: uint8((y * 255) / height),
+				B: uint8((x + y) % 255),
+				A: 255,
+			})
+		}
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sample.png")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("os.Create() error = %v", err)
+	}
+	defer file.Close()
+	if err := png.Encode(file, img); err != nil {
+		t.Fatalf("png.Encode() error = %v", err)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("os.ReadFile() error = %v", err)
+	}
+	return path, content
+}


### PR DESCRIPTION
Fixed #18

## 背景

在 IM 网关接入微信图片发送后，链路表面上已经返回成功：

- `getuploadurl` 成功
- CDN 上传成功
- `sendmessage` 成功
- 后端事件表里也会记录 `send_image`

但真实用户侧表现有两个异常阶段：

1. 最初可以收到“图片消息”，但点开后显示“图片已过期”或“已经被清理”
2. 后续在尝试补缩略图字段后，甚至出现“图片和文字都收不到”或“图片完全不展示”

这说明问题不在 Dashboard，不在调试入口，也不在 MySQL 落库，而是在 **微信图片协议实现和官方实现存在偏差**。

## 根因分析

这次修复不是继续猜微信字段，而是直接回到 `Tencent/openclaw-weixin` 的官方实现逐项对比。排查结论有两个关键点：

### 1. 我们之前错误地假设图片发送必须补缩略图上传链路

此前为了修复“图片已过期”，我尝试补了：

- `thumb_rawsize`
- `thumb_rawfilemd5`
- `thumb_filesize`
- `thumb_upload_param`
- `thumb_media`
- `thumb_size / thumb_width / thumb_height / hd_size`

但从线上日志看，微信实际返回的 `getuploadurl` 响应里 **并不返回 `thumb_upload_param`**。

而且继续强行构造 `thumb_media` / fallback thumb payload 后，用户侧反而连图片都不展示。这说明这条协议假设不成立。

### 2. `openclaw-weixin` 官方实现实际走的是更简单的图片消息体

对照官方仓库后确认：

- `getuploadurl` 只上传原图参数
- `no_need_thumb = true`
- 不单独上传缩略图
- `sendmessage` 的 `image_item` 只保留：
  - `media.encrypt_query_param`
  - `media.aes_key`
  - `mid_size`

也就是说，之前那套“补缩略图字段”的方向本身就偏离了官方实现。

另外还发现一个重要细节：

- `media.aes_key` 的编码方式也必须和官方实现保持一致

这也是图片无法被微信客户端正常取回和解密的高风险点。

## 修复方案

这次修复做了 3 件事。

### 1. 图片发送链路严格对齐 `openclaw-weixin`

在 `internal/im/wechat_image.go` 中，重新收敛为官方实现：

- `getuploadurl` 只发送原图参数
- `no_need_thumb = true`
- 只上传一份原图密文到微信 CDN
- `sendmessage` 的 `image_item` 只构造官方实现中真实使用的字段
- `media.aes_key` 的编码方式与官方实现保持一致

这样做的目的很明确：

- 不再继续猜测微信私有字段
- 直接复用已被官方项目验证过的协议形态
- 把问题面从“我们自己发明了一套图片协议”收敛到“严格兼容官方实现”

### 2. 补充图片链路运行时日志，便于继续排障

在 `internal/im/service.go` 和 `internal/im/wechat_image.go` 中增加了更完整的 runtime log：

- 图片投递开始
- 微信图片发送开始
- 上传 URL 请求
- CDN 上传开始 / 成功
- 微信 `sendmessage` 成功 / 失败
- IM 图片投递成功 / 失败

这样如果后续还有协议细节问题，AI 或开发者只看日志就能快速判断问题落在哪一层：

- Dashboard 调试入口
- IM service
- 微信 adapter
- CDN 上传
- sendmessage

### 3. 修复 `im_events` 主键冲突问题

在排查图片问题时，还顺手暴露出一个独立 bug：

- `im_events` 的 ID 之前只靠进程内自增生成
- 服务重启后可能重新从 `imevent_1` 开始
- 导致 `Duplicate entry 'imevent_1' for key 'im_events.PRIMARY'`

这次一起修掉了：

- `nextID` 改成 `prefix + UnixNano + seq`
- 避免服务重启后重复生成同一个事件 ID

同时把 `AppendEvent` 的失败也明确打进 runtime log，避免“事件插入失败但表面无感知”。

## 代码改动

主要涉及：

- `internal/im/wechat_image.go`
  - 对齐官方微信图片发送协议
- `internal/im/wechat_adapter.go`
  - 适配器补充 CDN 基础地址配置承载
- `internal/im/service.go`
  - 补 runtime log，统一事件写入错误处理
- `internal/im/store.go`
  - 修复 IM 事件 ID 生成冲突
- `internal/im/wechat_image_test.go`
  - 增加对齐官方实现的图片发送测试

## 验证

已通过：

- `GOCACHE=$(pwd)/.gocache go test ./...`
- `npm run build:web`

并且本地通过 Dashboard 调试入口验证：

- 微信现在可以收到正常图片

## 额外说明

这次修复的关键不是“把图片字段补得更复杂”，而是 **停止猜微信协议，回到官方实现做一比一对齐**。

这也是后续继续扩展视频、文件等媒体消息时的策略：

- 优先以 `openclaw-weixin` 的已验证实现为基线
- 避免自造一套看起来合理、但实际上不兼容微信客户端的协议组合