### PR TITLE
feat: 增加微信文件调试发送能力

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Current responsibilities:
 - run `reply` generation for normal chat and tool-result summarization
 - drive local TTS playback on the device through the existing client protocol
 - maintain lightweight async tasks
-- provide phase-1 IM gateway capability for WeChat text delivery plus default-channel image debug send
+- provide phase-1 IM gateway capability for WeChat text delivery plus default-channel image/file debug send
 - persist backend runtime logs and expose them through the dashboard API
 - expose a React dashboard over API + web frontend
 
@@ -207,11 +207,11 @@ IM gateway store:
   - logged-in IM accounts
   - default text delivery targets
   - recent IM gateway events
-- current scope is text delivery plus default-channel image debug send
+- current scope is text delivery plus default-channel image/file debug send
 
 Media cache:
 
-- uploaded IM debug images are cached on local disk before adapter delivery
+- uploaded IM debug images/files are cached on local disk before adapter delivery
 - cache directory comes from `config.yaml` field `im.media_cache_dir`
 - current default is `.cache/im-media` under the repo root
 - files are intentionally not auto-cleaned yet

--- a/docs/im-delivery.md
+++ b/docs/im-delivery.md
@@ -1,0 +1,442 @@
+# 微信适配层发送说明
+
+这份文档只讲一件事：当前微信适配层本身是怎么发文字、怎么发图片、怎么发文件的。
+
+它不解释 IM 网关、不解释 Dashboard，也不解释主流程什么时候触发发送。这里只看微信协议适配这一层到底做了什么。
+
+## 适配层职责
+
+微信适配层的职责很单纯：
+
+1. 接收一份已经确定好的发送请求。
+2. 把这份请求转换成微信 `ilink` HTTP 接口能接受的格式。
+3. 发起真正的 HTTP 请求。
+4. 把微信返回结果转换成统一的发送结果。
+
+也就是说，这一层不做：
+
+- 默认账号选择
+- 默认目标选择
+- 配置判断
+- 上层业务编排
+
+它只做“把消息按微信协议发出去”。
+
+## 1. 微信适配层的公共请求基础
+
+不管是发文字还是发图片，微信适配层都会复用同一套基础请求能力。
+
+### 1.1 HTTP 客户端
+
+当前适配层内部维护一个 `http.Client`，默认请求超时是 15 秒。
+
+这个超时主要覆盖：
+
+- `sendmessage`
+- `getuploadurl`
+- 其他微信 bot HTTP 接口
+
+### 1.2 公共请求头
+
+每次请求都会带上微信侧要求的公共头：
+
+- `iLink-App-Id`
+- `iLink-App-ClientVersion`
+- `X-WECHAT-UIN`
+
+对于 `POST` 请求，还会继续带上：
+
+- `Content-Type: application/json`
+- `AuthorizationType: ilink_bot_token`
+- `Content-Length`
+- `Authorization: Bearer <token>`
+
+其中：
+
+- `X-WECHAT-UIN` 是一个随机 `uint32` 转十进制字符串后再做 base64
+- `Authorization` 来自扫码登录拿到的 bot token
+
+### 1.3 公共请求体包装
+
+微信这套接口不是直接收一段裸消息，而是要求统一包在：
+
+- `msg`
+- `base_info`
+
+其中 `base_info` 里当前主要带：
+
+- `channel_version`
+
+所以适配层发消息时，最终都会是：
+
+```json
+{
+  "msg": { ... },
+  "base_info": {
+    "channel_version": "open-xiaoai-agent"
+  }
+}
+```
+
+## 2. 文字发送怎么做
+
+文字发送是最简单的一条链路。
+
+### 2.1 输入
+
+适配层拿到的输入只有三块：
+
+- 微信账号信息
+- 目标用户信息
+- 一段文本
+
+文字会先做一次 `trim`，如果内容为空就直接返回错误。
+
+### 2.2 构造消息
+
+适配层会先生成一个随机 `client_id`，然后构造微信消息体：
+
+```json
+{
+  "msg": {
+    "from_user_id": "",
+    "to_user_id": "<target user id>",
+    "client_id": "<random hex>",
+    "message_type": 2,
+    "message_state": 2,
+    "item_list": [
+      {
+        "type": 1,
+        "text_item": {
+          "text": "你好"
+        }
+      }
+    ]
+  },
+  "base_info": {
+    "channel_version": "open-xiaoai-agent"
+  }
+}
+```
+
+这里几个关键字段的含义可以简单理解成：
+
+- `to_user_id`：发给谁
+- `client_id`：客户端生成的消息标识
+- `message_type = 2`：bot 消息
+- `message_state = 2`：完成态消息
+- `type = 1`：文本 item
+
+### 2.3 实际发送
+
+消息体组好以后，适配层直接调用：
+
+- `POST /ilink/bot/sendmessage`
+
+如果微信返回 2xx，就认为文本发送成功，并把这次的 `client_id` 作为 `MessageID` 返回给上层。
+
+所以文字发送的本质就是：
+
+1. 组一个只有 `text_item` 的 `item_list`
+2. 调 `sendmessage`
+3. 返回 `client_id`
+
+## 3. 图片发送怎么做
+
+图片发送比文字复杂很多，因为微信图片不是“直接把二进制塞进 `sendmessage`”。
+
+它实际是两段式：
+
+1. 先把图片上传到微信 CDN
+2. 再发一条引用这张图片的消息
+
+### 3.1 输入
+
+图片发送当前拿到的输入是：
+
+- 微信账号信息
+- 目标用户信息
+- 一张已经存在本地的图片文件
+- 可选的 `caption`
+
+如果有 `caption`，适配层会先复用文字发送逻辑，先发一条文本，再继续发图。
+
+这意味着“文字说明 + 图片”在微信侧不是一个复合 item，而是两条独立消息。
+
+### 3.2 读取原图并准备加密参数
+
+适配层会先读取本地图片文件，然后生成：
+
+- `filekey`
+- 16 字节随机 AES key
+
+接着计算原图：
+
+- 明文大小 `rawsize`
+- 明文 MD5 `rawfilemd5`
+- AES-128-ECB + PKCS7 加密后的密文
+- 密文大小 `filesize`
+
+这里最关键的是：
+
+- 微信 CDN 上传的是加密后的图片
+- 后续消息里引用的不是本地文件，而是 CDN 上那份加密资源
+
+### 3.3 获取上传参数
+
+原图准备好后，适配层会先调用：
+
+- `POST /ilink/bot/getuploadurl`
+
+请求体当前已经明确对齐 `openclaw-weixin` 官方实现，只带原图参数：
+
+```json
+{
+  "filekey": "<filekey>",
+  "media_type": 1,
+  "to_user_id": "<target user id>",
+  "rawsize": 12345,
+  "rawfilemd5": "<md5>",
+  "filesize": 12352,
+  "no_need_thumb": true,
+  "aeskey": "<hex aes key>",
+  "base_info": {
+    "channel_version": "open-xiaoai-agent"
+  }
+}
+```
+
+这里几个关键点是：
+
+- `media_type = 1` 表示图片
+- `no_need_thumb = true`
+- 当前不走单独的缩略图上传链路
+- `aeskey` 这里传的是十六进制字符串
+
+微信返回后，适配层会拿到：
+
+- `upload_full_url`
+  或
+- `upload_param`
+
+如果只有 `upload_param`，适配层会自己拼 CDN 上传地址。
+
+### 3.4 上传到微信 CDN
+
+拿到上传参数后，适配层会把前面生成好的密文图片上传到微信 CDN。
+
+上传请求是：
+
+- `POST <cdn upload url>`
+- `Content-Type: application/octet-stream`
+- 请求体直接是加密后的图片字节
+
+上传成功后，CDN 响应头里会返回：
+
+- `x-encrypted-param`
+
+这个值非常关键，它就是后面图片消息里要引用的：
+
+- `encrypt_query_param`
+
+### 3.5 构造图片消息
+
+图片真正发给微信用户时，不再带图片二进制，而是带一份图片引用描述。
+
+当前已经对齐 `openclaw-weixin` 官方实现，最终 `image_item` 只保留最小字段：
+
+```json
+{
+  "media": {
+    "encrypt_query_param": "<cdn encrypted param>",
+    "aes_key": "<encoded aes key>",
+    "encrypt_type": 1
+  },
+  "mid_size": 12352
+}
+```
+
+再把它包进 `item_list`：
+
+```json
+{
+  "msg": {
+    "from_user_id": "",
+    "to_user_id": "<target user id>",
+    "client_id": "<random hex>",
+    "message_type": 2,
+    "message_state": 2,
+    "item_list": [
+      {
+        "type": 2,
+        "image_item": {
+          "media": {
+            "encrypt_query_param": "<cdn encrypted param>",
+            "aes_key": "<encoded aes key>",
+            "encrypt_type": 1
+          },
+          "mid_size": 12352
+        }
+      }
+    ]
+  },
+  "base_info": {
+    "channel_version": "open-xiaoai-agent"
+  }
+}
+```
+
+然后再调用：
+
+- `POST /ilink/bot/sendmessage`
+
+如果返回 2xx，就认为图片消息已经发送成功。
+
+## 4. 图片发送为什么最后回到官方实现
+
+这部分是当前微信适配层里最重要的实现经验。
+
+之前为了修图片显示异常，曾经尝试过补：
+
+- 缩略图上传参数
+- `thumb_media`
+- `thumb_size`
+- `thumb_width`
+- `thumb_height`
+- `hd_size`
+
+但真实线上表现说明这条方向不对：
+
+1. 微信 `getuploadurl` 实际并不会稳定返回 `thumb_upload_param`
+2. 强行补一套缩略图字段后，客户端表现反而更差
+
+最后真正稳定的做法，是回到 `Tencent/openclaw-weixin` 的实际实现，一比一对齐：
+
+- `getuploadurl` 只传原图参数
+- `no_need_thumb = true`
+- 不单独上传缩略图
+- `image_item` 只保留官方实际使用的最小字段集合
+
+也就是说，当前图片发送能正常工作，不是因为“字段补得越来越多”，而是因为“停止猜协议，回到官方实现”。
+
+## 4. 文件发送怎么做
+
+文件发送和图片发送非常像，本质上也是两段式：
+
+1. 先把文件上传到微信 CDN
+2. 再发一条引用这个文件的消息
+
+### 4.1 输入
+
+文件发送当前拿到的输入是：
+
+- 微信账号信息
+- 目标用户信息
+- 一个已经存在本地的文件
+- 可选的 `caption`
+
+如果有 `caption`，适配层同样会先复用文字发送逻辑，先发一条文本，再继续发文件。
+
+### 4.2 上传阶段
+
+文件上传阶段和图片现在共用同一套适配层公共骨架：
+
+- 读取本地文件
+- 生成 `filekey`
+- 生成 16 字节随机 AES key
+- 计算明文大小、MD5、密文大小
+- 调 `POST /ilink/bot/getuploadurl`
+- 把 AES-128-ECB + PKCS7 后的密文上传到微信 CDN
+- 取回 `x-encrypted-param`
+
+区别主要只有两个：
+
+- `media_type = 3`
+- 仍然带 `no_need_thumb = true`
+
+也就是说，文件发送不走缩略图逻辑。
+
+### 4.3 构造文件消息
+
+当前文件消息体同样是按 `openclaw-weixin` 已验证实现来做，核心 `file_item` 是：
+
+```json
+{
+  "media": {
+    "encrypt_query_param": "<cdn encrypted param>",
+    "aes_key": "<encoded aes key>",
+    "encrypt_type": 1
+  },
+  "file_name": "story.txt",
+  "len": "12345"
+}
+```
+
+其中：
+
+- `file_name` 是展示给微信用户的文件名
+- `len` 是原文件明文字节数，注意这里是字符串
+
+再把它包进 `item_list` 后，仍然调用：
+
+- `POST /ilink/bot/sendmessage`
+
+### 4.4 为什么文件也复用了图片的上传骨架
+
+因为微信侧文件和图片真正共享的是上传协议，而不是消息 item 名称。
+
+它们共同依赖的其实是：
+
+- `getuploadurl`
+- AES key 生成
+- 原文 MD5
+- CDN 密文上传
+- `encrypt_query_param`
+
+真正分叉的地方只有：
+
+- `media_type`
+- 最终是 `image_item` 还是 `file_item`
+
+所以当前实现里，上传和鉴权复用的是同一套 helper，避免图片和文件各自维护一套几乎一样的协议细节。
+
+## 5. 文字、图片、文件在适配层的根本区别
+
+可以把三者的差别压缩成下面这张表。
+
+| 维度 | 文字发送 | 图片发送 | 文件发送 |
+|---|---|---|---|
+| 是否直接调用 `sendmessage` | 是 | 否，先上传 CDN 再 `sendmessage` | 否，先上传 CDN 再 `sendmessage` |
+| 是否需要读本地文件 | 否 | 是 | 是 |
+| 是否需要生成 AES key | 否 | 是 | 是 |
+| 是否需要计算 MD5 | 否 | 是 | 是 |
+| 是否需要调用 `getuploadurl` | 否 | 是 | 是 |
+| 是否需要上传二进制到 CDN | 否 | 是 | 是 |
+| `item_list` 类型 | `text_item` | `image_item` | `file_item` |
+
+所以从适配层视角看：
+
+- 文字发送是“直接发消息”
+- 图片发送是“先上传资源，再发消息引用”
+- 文件发送也是“先上传资源，再发消息引用”
+
+## 6. 当前微信适配层的实现边界
+
+当前这层已经支持：
+
+- 文本发送
+- 图片发送
+- 文件发送
+- 图片附带一条前置 caption 文本
+- 文件附带一条前置 caption 文本
+
+但还没有做的是：
+
+- 视频发送
+- 图片自动缩略图上传链路
+- 统一媒体消息抽象
+
+所以如果后面继续扩展这层，最稳的方向仍然是：
+
+- 先对齐 `openclaw-weixin` 已验证实现
+- 再把同样的模式扩到视频、文件等媒体类型

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -35,6 +35,7 @@ type Server struct {
 		ConfirmWeChatLogin(sessionKey string) (im.Account, error)
 		SendTextToDefaultChannel(text string) (im.DeliveryReceipt, error)
 		SendImageToDefaultChannel(req im.ImageSendRequest) (im.DeliveryReceipt, error)
+		SendFileToDefaultChannel(req im.FileSendRequest) (im.DeliveryReceipt, error)
 		UpsertTarget(accountID string, name string, targetUserID string, setDefault bool) (im.Target, error)
 		SetDefaultTarget(accountID string, targetID string) error
 		DeleteTarget(targetID string) error
@@ -60,6 +61,7 @@ func New(addr string, tasks *tasks.Manager, claude *complextask.Service, convers
 	ConfirmWeChatLogin(sessionKey string) (im.Account, error)
 	SendTextToDefaultChannel(text string) (im.DeliveryReceipt, error)
 	SendImageToDefaultChannel(req im.ImageSendRequest) (im.DeliveryReceipt, error)
+	SendFileToDefaultChannel(req im.FileSendRequest) (im.DeliveryReceipt, error)
 	UpsertTarget(accountID string, name string, targetUserID string, setDefault bool) (im.Target, error)
 	SetDefaultTarget(accountID string, targetID string) error
 	DeleteTarget(targetID string) error
@@ -93,6 +95,7 @@ func (s *Server) ListenAndServe() error {
 	mux.HandleFunc("/api/im/wechat/login/confirm", s.handleWeChatLoginConfirm)
 	mux.HandleFunc("/api/im/debug/send-default", s.handleIMDebugSendDefault)
 	mux.HandleFunc("/api/im/debug/send-image-default", s.handleIMDebugSendImageDefault)
+	mux.HandleFunc("/api/im/debug/send-file-default", s.handleIMDebugSendFileDefault)
 	mux.HandleFunc("/api/im/targets", s.handleIMTargets)
 	mux.HandleFunc("/api/im/targets/default", s.handleIMTargetDefault)
 	mux.HandleFunc("/api/im/targets/delete", s.handleIMTargetDelete)
@@ -379,28 +382,16 @@ func (s *Server) handleIMDebugSendImageDefault(w http.ResponseWriter, r *http.Re
 		http.Error(w, "im gateway is not configured", http.StatusServiceUnavailable)
 		return
 	}
-	if err := r.ParseMultipartForm(16 << 20); err != nil {
+	upload, err := parseUploadedFile(r, 16<<20, "file")
+	if err != nil {
 		http.Error(w, fmt.Sprintf("parse image upload form: %v", err), http.StatusBadRequest)
 		return
 	}
 
-	file, header, err := r.FormFile("file")
-	if err != nil {
-		http.Error(w, fmt.Sprintf("read image upload file: %v", err), http.StatusBadRequest)
-		return
-	}
-	defer file.Close()
-
-	content, err := io.ReadAll(file)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("read image upload content: %v", err), http.StatusBadRequest)
-		return
-	}
-
 	receipt, err := s.im.SendImageToDefaultChannel(im.ImageSendRequest{
-		FileName: header.Filename,
-		MimeType: header.Header.Get("Content-Type"),
-		Content:  content,
+		FileName: upload.FileName,
+		MimeType: upload.MimeType,
+		Content:  upload.Content,
 		Caption:  r.FormValue("caption"),
 	})
 	if err != nil {
@@ -411,6 +402,67 @@ func (s *Server) handleIMDebugSendImageDefault(w http.ResponseWriter, r *http.Re
 		"ok":      true,
 		"receipt": receipt,
 	})
+}
+
+func (s *Server) handleIMDebugSendFileDefault(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.im == nil {
+		http.Error(w, "im gateway is not configured", http.StatusServiceUnavailable)
+		return
+	}
+	upload, err := parseUploadedFile(r, 32<<20, "file")
+	if err != nil {
+		http.Error(w, fmt.Sprintf("parse file upload form: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	receipt, err := s.im.SendFileToDefaultChannel(im.FileSendRequest{
+		FileName: upload.FileName,
+		MimeType: upload.MimeType,
+		Content:  upload.Content,
+		Caption:  r.FormValue("caption"),
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	writeJSON(w, map[string]any{
+		"ok":      true,
+		"receipt": receipt,
+	})
+}
+
+type uploadedFormFile struct {
+	FileName string
+	MimeType string
+	Content  []byte
+}
+
+func parseUploadedFile(r *http.Request, maxMemory int64, fieldName string) (uploadedFormFile, error) {
+	if err := r.ParseMultipartForm(maxMemory); err != nil {
+		return uploadedFormFile{}, err
+	}
+
+	file, header, err := r.FormFile(fieldName)
+	if err != nil {
+		return uploadedFormFile{}, err
+	}
+	defer file.Close()
+
+	content, err := io.ReadAll(file)
+	if err != nil {
+		return uploadedFormFile{}, err
+	}
+
+	return uploadedFormFile{
+		FileName: header.Filename,
+		MimeType: header.Header.Get("Content-Type"),
+		Content:  content,
+	}, nil
 }
 
 func (s *Server) handleIMTargets(w http.ResponseWriter, r *http.Request) {

--- a/internal/dashboard/server_test.go
+++ b/internal/dashboard/server_test.go
@@ -67,6 +67,7 @@ type fakeIM struct {
 	confirmSession  string
 	debugText       string
 	debugImage      im.ImageSendRequest
+	debugFile       im.FileSendRequest
 	debugReceipt    im.DeliveryReceipt
 	resetCalls      int
 }
@@ -165,6 +166,29 @@ func (f *fakeIM) SendImageToDefaultChannel(req im.ImageSendRequest) (im.Delivery
 		},
 		MessageID:     "img_1",
 		Kind:          im.DeliveryKindImage,
+		Caption:       req.Caption,
+		MediaFileName: req.FileName,
+		MediaMimeType: req.MimeType,
+	}, nil
+}
+
+func (f *fakeIM) SendFileToDefaultChannel(req im.FileSendRequest) (im.DeliveryReceipt, error) {
+	f.debugFile = req
+	return im.DeliveryReceipt{
+		Account: im.Account{
+			ID:              "account_1",
+			Platform:        im.PlatformWeChat,
+			RemoteAccountID: "bot@im.bot",
+			DisplayName:     "bot@im.bot",
+		},
+		Target: im.Target{
+			ID:           "target_1",
+			AccountID:    "account_1",
+			Name:         "我的微信",
+			TargetUserID: "user@im.wechat",
+		},
+		MessageID:     "file_1",
+		Kind:          im.DeliveryKindFile,
 		Caption:       req.Caption,
 		MediaFileName: req.FileName,
 		MediaMimeType: req.MimeType,
@@ -463,6 +487,65 @@ func TestHandleIMDebugSendImageDefaultUsesUploadedFile(t *testing.T) {
 	}
 	if payload.Receipt.MediaFileName != "rabbit.png" {
 		t.Fatalf("MediaFileName = %q, want rabbit.png", payload.Receipt.MediaFileName)
+	}
+}
+
+func TestHandleIMDebugSendFileDefaultUsesUploadedFile(t *testing.T) {
+	t.Parallel()
+
+	imGateway := &fakeIM{}
+	server := New(":0", nil, nil, nil, &fakeSettings{snapshot: settings.Snapshot{SessionWindowSeconds: 300}}, imGateway, &fakeLogs{})
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	fileWriter, err := writer.CreateFormFile("file", "story.txt")
+	if err != nil {
+		t.Fatalf("CreateFormFile() error = %v", err)
+	}
+	if _, err := fileWriter.Write([]byte("file-data")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if err := writer.WriteField("caption", "测试文件"); err != nil {
+		t.Fatalf("WriteField() error = %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/im/debug/send-file-default", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	recorder := httptest.NewRecorder()
+
+	server.handleIMDebugSendFileDefault(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if imGateway.debugFile.FileName != "story.txt" {
+		t.Fatalf("FileName = %q, want story.txt", imGateway.debugFile.FileName)
+	}
+	if string(imGateway.debugFile.Content) != "file-data" {
+		t.Fatalf("Content = %q, want file-data", string(imGateway.debugFile.Content))
+	}
+	if imGateway.debugFile.Caption != "测试文件" {
+		t.Fatalf("Caption = %q, want 测试文件", imGateway.debugFile.Caption)
+	}
+
+	var payload struct {
+		OK      bool               `json:"ok"`
+		Receipt im.DeliveryReceipt `json:"receipt"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if !payload.OK {
+		t.Fatal("OK = false, want true")
+	}
+	if payload.Receipt.Kind != im.DeliveryKindFile {
+		t.Fatalf("Kind = %q, want %q", payload.Receipt.Kind, im.DeliveryKindFile)
+	}
+	if payload.Receipt.MediaFileName != "story.txt" {
+		t.Fatalf("MediaFileName = %q, want story.txt", payload.Receipt.MediaFileName)
 	}
 }
 

--- a/internal/im/adapter.go
+++ b/internal/im/adapter.go
@@ -21,4 +21,5 @@ type Adapter interface {
 	PollLogin(ctx context.Context, sessionKey string) (WeChatLoginResult, error)
 	SendText(ctx context.Context, account Account, target Target, text string) (TextSendResult, error)
 	SendImage(ctx context.Context, account Account, target Target, image PreparedImage, caption string) (ImageSendResult, error)
+	SendFile(ctx context.Context, account Account, target Target, file PreparedFile, caption string) (FileSendResult, error)
 }

--- a/internal/im/media_cache.go
+++ b/internal/im/media_cache.go
@@ -15,6 +15,13 @@ type MediaCache struct {
 	dir string
 }
 
+type preparedCachedMedia struct {
+	FilePath string
+	FileName string
+	MimeType string
+	Size     int64
+}
+
 func NewMediaCache(dir string) (*MediaCache, error) {
 	dir = strings.TrimSpace(dir)
 	if dir == "" {
@@ -37,22 +44,46 @@ func (c *MediaCache) StoreImage(req ImageSendRequest) (PreparedImage, error) {
 	if c == nil {
 		return PreparedImage{}, fmt.Errorf("media cache is not configured")
 	}
+	prepared, err := c.storeMedia(req.FileName, req.MimeType, req.Content, "weixin-image", ".img", func(mimeType string) error {
+		if !strings.HasPrefix(strings.ToLower(mimeType), "image/") {
+			return fmt.Errorf("only image uploads are supported, got %q", mimeType)
+		}
+		return nil
+	})
+	if err != nil {
+		return PreparedImage{}, err
+	}
+	return PreparedImage(prepared), nil
+}
 
-	content := req.Content
+func (c *MediaCache) StoreFile(req FileSendRequest) (PreparedFile, error) {
+	if c == nil {
+		return PreparedFile{}, fmt.Errorf("media cache is not configured")
+	}
+	prepared, err := c.storeMedia(req.FileName, req.MimeType, req.Content, "weixin-file", ".bin", nil)
+	if err != nil {
+		return PreparedFile{}, err
+	}
+	return PreparedFile(prepared), nil
+}
+
+func (c *MediaCache) storeMedia(fileName string, mimeType string, content []byte, defaultPrefix string, defaultExt string, validate func(string) error) (preparedCachedMedia, error) {
 	if len(content) == 0 {
-		return PreparedImage{}, fmt.Errorf("image content is required")
+		return preparedCachedMedia{}, fmt.Errorf("media content is required")
 	}
 
-	fileName := filepath.Base(strings.TrimSpace(req.FileName))
+	fileName = filepath.Base(strings.TrimSpace(fileName))
 	if fileName == "." || fileName == string(filepath.Separator) {
 		fileName = ""
 	}
-	mimeType := strings.TrimSpace(req.MimeType)
+	mimeType = strings.TrimSpace(mimeType)
 	if mimeType == "" {
 		mimeType = http.DetectContentType(content)
 	}
-	if !strings.HasPrefix(strings.ToLower(mimeType), "image/") {
-		return PreparedImage{}, fmt.Errorf("only image uploads are supported, got %q", mimeType)
+	if validate != nil {
+		if err := validate(mimeType); err != nil {
+			return preparedCachedMedia{}, err
+		}
 	}
 
 	ext := strings.TrimSpace(filepath.Ext(fileName))
@@ -62,24 +93,24 @@ func (c *MediaCache) StoreImage(req ImageSendRequest) (PreparedImage, error) {
 		}
 	}
 	if ext == "" {
-		ext = ".img"
+		ext = defaultExt
 	}
 
 	prefix := sanitizeMediaBaseName(strings.TrimSuffix(fileName, filepath.Ext(fileName)))
 	if prefix == "" {
-		prefix = "weixin-image"
+		prefix = defaultPrefix
 	}
 	token, err := randomMediaToken(8)
 	if err != nil {
-		return PreparedImage{}, err
+		return preparedCachedMedia{}, err
 	}
 	storedName := fmt.Sprintf("%s-%s%s", prefix, token, ext)
 	filePath := filepath.Join(c.dir, storedName)
 	if err := os.WriteFile(filePath, content, 0o644); err != nil {
-		return PreparedImage{}, fmt.Errorf("write cached image: %w", err)
+		return preparedCachedMedia{}, fmt.Errorf("write cached media: %w", err)
 	}
 
-	return PreparedImage{
+	return preparedCachedMedia{
 		FilePath: filePath,
 		FileName: chooseMediaFileName(fileName, storedName),
 		MimeType: mimeType,

--- a/internal/im/model.go
+++ b/internal/im/model.go
@@ -6,6 +6,7 @@ const (
 	PlatformWeChat    = "weixin"
 	DeliveryKindText  = "text"
 	DeliveryKindImage = "image"
+	DeliveryKindFile  = "file"
 )
 
 type Account struct {
@@ -70,6 +71,13 @@ type PreparedImage struct {
 	Size     int64
 }
 
+type PreparedFile struct {
+	FilePath string
+	FileName string
+	MimeType string
+	Size     int64
+}
+
 type ImageSendRequest struct {
 	FileName string
 	MimeType string
@@ -78,6 +86,17 @@ type ImageSendRequest struct {
 }
 
 type ImageSendResult struct {
+	MessageID string
+}
+
+type FileSendRequest struct {
+	FileName string
+	MimeType string
+	Content  []byte
+	Caption  string
+}
+
+type FileSendResult struct {
 	MessageID string
 }
 

--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -305,6 +305,23 @@ func (s *Service) SendImageToDefaultChannel(req ImageSendRequest) (DeliveryRecei
 	return s.deliverImage(cfg.IMSelectedAccountID, cfg.IMSelectedTargetID, prepared, req.Caption)
 }
 
+func (s *Service) SendFileToDefaultChannel(req FileSendRequest) (DeliveryReceipt, error) {
+	if s == nil || s.store == nil || s.settings == nil || s.mediaCache == nil {
+		return DeliveryReceipt{}, fmt.Errorf("im service is not configured")
+	}
+
+	cfg := s.settings.Snapshot()
+	if strings.TrimSpace(cfg.IMSelectedAccountID) == "" || strings.TrimSpace(cfg.IMSelectedTargetID) == "" {
+		return DeliveryReceipt{}, fmt.Errorf("默认渠道尚未配置，请先保存账号和触达目标")
+	}
+
+	prepared, err := s.mediaCache.StoreFile(req)
+	if err != nil {
+		return DeliveryReceipt{}, err
+	}
+	return s.deliverFile(cfg.IMSelectedAccountID, cfg.IMSelectedTargetID, prepared, req.Caption)
+}
+
 func (s *Service) Reset() error {
 	if s == nil || s.store == nil {
 		return nil
@@ -421,6 +438,43 @@ func (s *Service) deliverImage(accountID string, targetID string, image Prepared
 		Caption:       strings.TrimSpace(caption),
 		MediaFileName: image.FileName,
 		MediaMimeType: image.MimeType,
+	}, nil
+}
+
+func (s *Service) deliverFile(accountID string, targetID string, file PreparedFile, caption string) (DeliveryReceipt, error) {
+	account, target, adapter, err := s.resolveDelivery(accountID, targetID)
+	if err != nil {
+		return DeliveryReceipt{}, err
+	}
+
+	log.Printf("im file delivery started: account=%s target=%s platform=%s file=%q mime=%s size=%d caption_len=%d", account.ID, target.ID, account.Platform, file.FileName, file.MimeType, file.Size, len(strings.TrimSpace(caption)))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	result, err := adapter.SendFile(ctx, account, target, file, caption)
+	if err != nil {
+		_ = s.store.MarkDeliveryFailure(account.ID, err.Error())
+		s.appendEvent(account.ID, "send_failed", fmt.Sprintf("发送文件到 %s 失败：%s", target.Name, err.Error()))
+		log.Printf("im file delivery failed: account=%s target=%s platform=%s file=%q err=%v", account.ID, target.ID, account.Platform, file.FileName, err)
+		return DeliveryReceipt{}, err
+	}
+
+	_ = s.store.MarkDeliverySuccess(account.ID)
+	eventLabel := strings.TrimSpace(caption)
+	if eventLabel == "" {
+		eventLabel = file.FileName
+	}
+	s.appendEvent(account.ID, "send_file", fmt.Sprintf("已发送文件到 %s：%s", target.Name, trimForEvent(eventLabel)))
+	log.Printf("im file delivery succeeded: account=%s target=%s platform=%s file=%q message_id=%s", account.ID, target.ID, account.Platform, file.FileName, result.MessageID)
+	return DeliveryReceipt{
+		Account:       account,
+		Target:        target,
+		MessageID:     result.MessageID,
+		Kind:          DeliveryKindFile,
+		Caption:       strings.TrimSpace(caption),
+		MediaFileName: file.FileName,
+		MediaMimeType: file.MimeType,
 	}, nil
 }
 

--- a/internal/im/service_test.go
+++ b/internal/im/service_test.go
@@ -18,6 +18,7 @@ type stubAdapter struct {
 	loginResult WeChatLoginResult
 	messages    []string
 	images      []PreparedImage
+	files       []PreparedFile
 	captions    []string
 }
 
@@ -57,6 +58,17 @@ func (s *stubAdapter) SendImage(ctx context.Context, account Account, target Tar
 	return ImageSendResult{MessageID: "img_1"}, nil
 }
 
+func (s *stubAdapter) SendFile(ctx context.Context, account Account, target Target, file PreparedFile, caption string) (FileSendResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.files = append(s.files, file)
+	s.captions = append(s.captions, caption)
+	if s.sendErr != nil {
+		return FileSendResult{}, s.sendErr
+	}
+	return FileSendResult{MessageID: "file_1"}, nil
+}
+
 func (s *stubAdapter) sentCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -67,6 +79,12 @@ func (s *stubAdapter) imageCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return len(s.images)
+}
+
+func (s *stubAdapter) fileCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.files)
 }
 
 func newTestService(t *testing.T) (*Service, *settings.Store) {
@@ -258,6 +276,55 @@ func TestServiceSendImageToDefaultChannelUsesSavedSelectionEvenWhenMirrorDisable
 	}
 	if adapter.imageCount() != 1 {
 		t.Fatalf("imageCount() = %d, want 1", adapter.imageCount())
+	}
+}
+
+func TestServiceSendFileToDefaultChannelUsesSavedSelectionEvenWhenMirrorDisabled(t *testing.T) {
+	t.Parallel()
+
+	service, _ := newTestService(t)
+
+	adapter := &stubAdapter{}
+	service.adapters["stub"] = adapter
+
+	account, err := service.store.UpsertAccount("stub", "bot@im.bot", "user@im.wechat", "Bot", "https://example.com", "token")
+	if err != nil {
+		t.Fatalf("UpsertAccount() error = %v", err)
+	}
+	target, err := service.store.UpsertTarget(account.ID, "我的微信", "user@im.wechat", true)
+	if err != nil {
+		t.Fatalf("UpsertTarget() error = %v", err)
+	}
+	if _, err := service.UpdateDeliveryConfig(false, account.ID, target.ID); err != nil {
+		t.Fatalf("UpdateDeliveryConfig() error = %v", err)
+	}
+
+	receipt, err := service.SendFileToDefaultChannel(FileSendRequest{
+		FileName: "story.txt",
+		MimeType: "text/plain",
+		Content:  []byte("hello from file"),
+		Caption:  "文件调试消息",
+	})
+	if err != nil {
+		t.Fatalf("SendFileToDefaultChannel() error = %v", err)
+	}
+	if receipt.Account.ID != account.ID {
+		t.Fatalf("receipt.Account.ID = %q, want %q", receipt.Account.ID, account.ID)
+	}
+	if receipt.Target.ID != target.ID {
+		t.Fatalf("receipt.Target.ID = %q, want %q", receipt.Target.ID, target.ID)
+	}
+	if receipt.Kind != DeliveryKindFile {
+		t.Fatalf("receipt.Kind = %q, want %q", receipt.Kind, DeliveryKindFile)
+	}
+	if receipt.Caption != "文件调试消息" {
+		t.Fatalf("receipt.Caption = %q, want 文件调试消息", receipt.Caption)
+	}
+	if receipt.MediaFileName != "story.txt" {
+		t.Fatalf("receipt.MediaFileName = %q, want story.txt", receipt.MediaFileName)
+	}
+	if adapter.fileCount() != 1 {
+		t.Fatalf("fileCount() = %d, want 1", adapter.fileCount())
 	}
 }
 

--- a/internal/im/wechat_file.go
+++ b/internal/im/wechat_file.go
@@ -1,0 +1,45 @@
+package im
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+)
+
+func (a *WeChatAdapter) SendFile(ctx context.Context, account Account, target Target, file PreparedFile, caption string) (FileSendResult, error) {
+	log.Printf("im wechat send file start: account=%s target=%s file=%q mime=%s size=%d caption_len=%d", account.ID, target.ID, file.FileName, file.MimeType, file.Size, len(strings.TrimSpace(caption)))
+
+	if strings.TrimSpace(caption) != "" {
+		if _, err := a.SendText(ctx, account, target, caption); err != nil {
+			return FileSendResult{}, err
+		}
+	}
+
+	uploaded, err := a.uploadMediaAsset(ctx, account, target, weChatMediaUploadRequest{
+		FilePath:  file.FilePath,
+		FileName:  file.FileName,
+		MediaType: weChatUploadMediaTypeFile,
+		LogLabel:  "file",
+	})
+	if err != nil {
+		return FileSendResult{}, err
+	}
+
+	fileItem := map[string]any{
+		"media": map[string]any{
+			"encrypt_query_param": uploaded.Original.DownloadEncryptedParam,
+			"aes_key":             encodeWeChatMediaAESKey(uploaded.AESKeyHex),
+			"encrypt_type":        1,
+		},
+		"file_name": file.FileName,
+		"len":       fmt.Sprintf("%d", uploaded.PlaintextBytes),
+	}
+
+	clientID, err := a.sendMediaItem(ctx, account, target, 4, "file_item", fileItem)
+	if err != nil {
+		return FileSendResult{}, err
+	}
+	log.Printf("im wechat send file succeeded: account=%s target=%s file=%q message_id=%s official_payload=true", account.ID, target.ID, file.FileName, clientID)
+	return FileSendResult{MessageID: clientID}, nil
+}

--- a/internal/im/wechat_file_test.go
+++ b/internal/im/wechat_file_test.go
@@ -1,0 +1,170 @@
+package im
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestWeChatAdapterSendFileMatchesOfficialPayload(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu             sync.Mutex
+		handlerErr     error
+		getUploadReq   map[string]any
+		sendMessageReq map[string]any
+		uploadCounts   = make(map[string]int)
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/ilink/bot/getuploadurl":
+			defer r.Body.Close()
+			payload := make(map[string]any)
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				mu.Lock()
+				handlerErr = err
+				mu.Unlock()
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			getUploadReq = payload
+			mu.Unlock()
+			writeJSON(t, w, map[string]any{
+				"upload_param": "file-param",
+			})
+		case "/cdn/upload":
+			kind := r.URL.Query().Get("encrypted_query_param")
+			mu.Lock()
+			uploadCounts[kind]++
+			mu.Unlock()
+			if kind == "" {
+				http.Error(w, "missing encrypted_query_param", http.StatusBadRequest)
+				mu.Lock()
+				handlerErr = errMissingQueryParam
+				mu.Unlock()
+				return
+			}
+			w.Header().Set("x-encrypted-param", "download-"+kind)
+			w.WriteHeader(http.StatusOK)
+		case "/ilink/bot/sendmessage":
+			defer r.Body.Close()
+			payload := make(map[string]any)
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				mu.Lock()
+				handlerErr = err
+				mu.Unlock()
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			sendMessageReq = payload
+			mu.Unlock()
+			writeJSON(t, w, map[string]any{})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	filePath := filepath.Join(t.TempDir(), "story.txt")
+	content := []byte("hello from wechat file delivery")
+	if err := os.WriteFile(filePath, content, 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	adapter := &WeChatAdapter{
+		client:     server.Client(),
+		cdnBaseURL: server.URL + "/cdn",
+		logins:     make(map[string]*activeWeChatLogin),
+	}
+
+	_, err := adapter.SendFile(context.Background(), Account{
+		ID:       "acc_1",
+		Platform: PlatformWeChat,
+		BaseURL:  server.URL,
+		Token:    "token",
+	}, Target{
+		ID:           "target_1",
+		AccountID:    "acc_1",
+		TargetUserID: "user@im.wechat",
+	}, PreparedFile{
+		FilePath: filePath,
+		FileName: filepath.Base(filePath),
+		MimeType: "text/plain",
+		Size:     int64(len(content)),
+	}, "")
+	if err != nil {
+		t.Fatalf("SendFile() error = %v", err)
+	}
+
+	mu.Lock()
+	if handlerErr != nil {
+		t.Fatalf("handler error = %v", handlerErr)
+	}
+	if getUploadReq == nil {
+		mu.Unlock()
+		t.Fatal("getuploadurl request was not captured")
+	}
+	if got := int(getUploadReq["media_type"].(float64)); got != weChatUploadMediaTypeFile {
+		mu.Unlock()
+		t.Fatalf("media_type = %d, want %d", got, weChatUploadMediaTypeFile)
+	}
+	if got := getUploadReq["no_need_thumb"].(bool); !got {
+		mu.Unlock()
+		t.Fatal("no_need_thumb = false, want true")
+	}
+	if _, ok := getUploadReq["thumb_rawsize"]; ok {
+		mu.Unlock()
+		t.Fatal("thumb_rawsize exists, want omitted")
+	}
+	if _, ok := getUploadReq["thumb_filesize"]; ok {
+		mu.Unlock()
+		t.Fatal("thumb_filesize exists, want omitted")
+	}
+	if _, ok := getUploadReq["thumb_rawfilemd5"]; ok {
+		mu.Unlock()
+		t.Fatal("thumb_rawfilemd5 exists, want omitted")
+	}
+
+	origUploads := uploadCounts["file-param"]
+	if sendMessageReq == nil {
+		mu.Unlock()
+		t.Fatal("sendmessage request was not captured")
+	}
+	sendReq := sendMessageReq
+	mu.Unlock()
+
+	if origUploads != 1 {
+		t.Fatalf("orig upload count = %d, want 1", origUploads)
+	}
+
+	msg := sendReq["msg"].(map[string]any)
+	itemList := msg["item_list"].([]any)
+	if len(itemList) != 1 {
+		t.Fatalf("len(item_list) = %d, want 1", len(itemList))
+	}
+	fileItem := itemList[0].(map[string]any)["file_item"].(map[string]any)
+	if got := fileItem["file_name"].(string); got != "story.txt" {
+		t.Fatalf("file_name = %q, want %q", got, "story.txt")
+	}
+	if got := fileItem["len"].(string); got != fmt.Sprintf("%d", len(content)) {
+		t.Fatalf("len = %q, want %q", got, fmt.Sprintf("%d", len(content)))
+	}
+
+	media := fileItem["media"].(map[string]any)
+	if got := media["encrypt_query_param"].(string); got != "download-file-param" {
+		t.Fatalf("media.encrypt_query_param = %q, want %q", got, "download-file-param")
+	}
+	if got := media["aes_key"].(string); got == "" {
+		t.Fatal("media.aes_key = empty, want encoded key")
+	}
+}

--- a/internal/im/wechat_image.go
+++ b/internal/im/wechat_image.go
@@ -1,39 +1,15 @@
 package im
 
 import (
-	"bytes"
 	"context"
-	"crypto/aes"
-	"crypto/md5"
-	"crypto/rand"
-	"encoding/base64"
-	"encoding/hex"
-	"encoding/json"
-	"fmt"
-	"io"
 	"log"
-	"net/http"
-	"net/url"
-	"os"
 	"strings"
 )
 
 const weChatDefaultCDNBaseURL = "https://novac2c.cdn.weixin.qq.com/c2c"
 
-type weChatGetUploadURLResponse struct {
-	UploadParam      string `json:"upload_param"`
-	ThumbUploadParam string `json:"thumb_upload_param"`
-	UploadFullURL    string `json:"upload_full_url"`
-}
-
-type weChatUploadedMedia struct {
-	DownloadEncryptedParam string
-	CiphertextBytes        int64
-}
-
 type weChatUploadedImage struct {
 	FileKey   string
-	AESKeyRaw []byte
 	AESKeyHex string
 	Original  weChatUploadedMedia
 }
@@ -52,43 +28,17 @@ func (a *WeChatAdapter) SendImage(ctx context.Context, account Account, target T
 		return ImageSendResult{}, err
 	}
 
-	clientID, err := randomWeChatToken(12)
-	if err != nil {
-		return ImageSendResult{}, err
-	}
-
 	imageItem := map[string]any{
 		"media": map[string]any{
 			"encrypt_query_param": uploaded.Original.DownloadEncryptedParam,
-			"aes_key":             base64.StdEncoding.EncodeToString([]byte(uploaded.AESKeyHex)),
+			"aes_key":             encodeWeChatMediaAESKey(uploaded.AESKeyHex),
 			"encrypt_type":        1,
 		},
 		"mid_size": uploaded.Original.CiphertextBytes,
 	}
 
-	body, err := json.Marshal(map[string]any{
-		"msg": map[string]any{
-			"from_user_id":  "",
-			"to_user_id":    target.TargetUserID,
-			"client_id":     clientID,
-			"message_type":  2,
-			"message_state": 2,
-			"item_list": []map[string]any{
-				{
-					"type":       2,
-					"image_item": imageItem,
-				},
-			},
-		},
-		"base_info": map[string]any{
-			"channel_version": weChatDefaultChannelLabel,
-		},
-	})
+	clientID, err := a.sendMediaItem(ctx, account, target, 2, "image_item", imageItem)
 	if err != nil {
-		return ImageSendResult{}, fmt.Errorf("encode wechat image message body: %w", err)
-	}
-
-	if _, err := a.postJSON(ctx, account.BaseURL, "ilink/bot/sendmessage", account.Token, body); err != nil {
 		return ImageSendResult{}, err
 	}
 	log.Printf("im wechat send image succeeded: account=%s target=%s file=%q message_id=%s official_payload=true", account.ID, target.ID, image.FileName, clientID)
@@ -96,162 +46,19 @@ func (a *WeChatAdapter) SendImage(ctx context.Context, account Account, target T
 }
 
 func (a *WeChatAdapter) uploadImage(ctx context.Context, account Account, target Target, image PreparedImage) (weChatUploadedImage, error) {
-	content, err := os.ReadFile(image.FilePath)
-	if err != nil {
-		return weChatUploadedImage{}, fmt.Errorf("read image file: %w", err)
-	}
-	fileKey, err := randomWeChatToken(16)
-	if err != nil {
-		return weChatUploadedImage{}, err
-	}
-	aesKeyRaw := make([]byte, 16)
-	if _, err := rand.Read(aesKeyRaw); err != nil {
-		return weChatUploadedImage{}, fmt.Errorf("generate image aes key: %w", err)
-	}
-
-	rawMD5 := md5.Sum(content)
-	ciphertext, err := encryptWeChatAESECB(content, aesKeyRaw)
-	if err != nil {
-		return weChatUploadedImage{}, err
-	}
-
-	log.Printf("im wechat image upload start: account=%s target=%s file=%q raw_bytes=%d", account.ID, target.ID, image.FileName, len(content))
-
-	aesKeyHex := hex.EncodeToString(aesKeyRaw)
-	uploadMeta, err := a.getUploadURL(ctx, account, target, fileKey, len(content), hex.EncodeToString(rawMD5[:]), len(ciphertext), aesKeyHex)
-	if err != nil {
-		return weChatUploadedImage{}, err
-	}
-	log.Printf("im wechat image upload url ready: account=%s target=%s file_key=%s official_flow=true", account.ID, target.ID, fileKey)
-
-	downloadParam, err := a.uploadImageCiphertext(ctx, uploadMeta.UploadFullURL, uploadMeta.UploadParam, fileKey, ciphertext, "image")
-	if err != nil {
-		return weChatUploadedImage{}, err
-	}
-	log.Printf("im wechat image upload succeeded: account=%s target=%s file=%q file_key=%s encrypted_bytes=%d official_flow=true", account.ID, target.ID, image.FileName, fileKey, len(ciphertext))
-
-	return weChatUploadedImage{
-		FileKey:   fileKey,
-		AESKeyRaw: aesKeyRaw,
-		AESKeyHex: aesKeyHex,
-		Original: weChatUploadedMedia{
-			DownloadEncryptedParam: downloadParam,
-			CiphertextBytes:        int64(len(ciphertext)),
-		},
-	}, nil
-}
-
-func (a *WeChatAdapter) getUploadURL(ctx context.Context, account Account, target Target, fileKey string, rawSize int, rawMD5 string, cipherSize int, aesKeyHex string) (weChatGetUploadURLResponse, error) {
-	log.Printf("im wechat image upload url request: account=%s target=%s file_key=%s raw_bytes=%d encrypted_bytes=%d official_flow=true", account.ID, target.ID, fileKey, rawSize, cipherSize)
-
-	body, err := json.Marshal(map[string]any{
-		"filekey":       fileKey,
-		"media_type":    1,
-		"to_user_id":    target.TargetUserID,
-		"rawsize":       rawSize,
-		"rawfilemd5":    rawMD5,
-		"filesize":      cipherSize,
-		"no_need_thumb": true,
-		"aeskey":        aesKeyHex,
-		"base_info": map[string]any{
-			"channel_version": weChatDefaultChannelLabel,
-		},
+	uploaded, err := a.uploadMediaAsset(ctx, account, target, weChatMediaUploadRequest{
+		FilePath:  image.FilePath,
+		FileName:  image.FileName,
+		MediaType: weChatUploadMediaTypeImage,
+		LogLabel:  "image",
 	})
 	if err != nil {
-		return weChatGetUploadURLResponse{}, fmt.Errorf("encode wechat upload url request: %w", err)
+		return weChatUploadedImage{}, err
 	}
 
-	respBody, err := a.postJSON(ctx, account.BaseURL, "ilink/bot/getuploadurl", account.Token, body)
-	if err != nil {
-		return weChatGetUploadURLResponse{}, err
-	}
-
-	var resp weChatGetUploadURLResponse
-	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return weChatGetUploadURLResponse{}, fmt.Errorf("decode wechat upload url response: %w", err)
-	}
-	if strings.TrimSpace(resp.UploadFullURL) == "" && strings.TrimSpace(resp.UploadParam) == "" {
-		return weChatGetUploadURLResponse{}, fmt.Errorf("wechat upload url response is missing upload_full_url and upload_param")
-	}
-	return resp, nil
-}
-
-func (a *WeChatAdapter) uploadImageCiphertext(ctx context.Context, uploadFullURL string, uploadParam string, fileKey string, ciphertext []byte, label string) (string, error) {
-	uploadURL := strings.TrimSpace(uploadFullURL)
-	if uploadURL == "" {
-		uploadURL = buildWeChatCDNUploadURL(a.cdnBaseURL, strings.TrimSpace(uploadParam), fileKey)
-	}
-	log.Printf("im wechat cdn upload start: kind=%s file_key=%s bytes=%d host=%s", label, fileKey, len(ciphertext), mustWeChatHost(uploadURL))
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadURL, bytes.NewReader(ciphertext))
-	if err != nil {
-		return "", fmt.Errorf("build wechat cdn upload request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/octet-stream")
-
-	resp, err := a.client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("wechat cdn upload failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("read wechat cdn upload response: %w", err)
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		message := strings.TrimSpace(resp.Header.Get("x-error-message"))
-		if message == "" {
-			message = strings.TrimSpace(string(respBody))
-		}
-		return "", fmt.Errorf("wechat cdn upload failed: status=%d body=%s", resp.StatusCode, message)
-	}
-
-	downloadParam := strings.TrimSpace(resp.Header.Get("x-encrypted-param"))
-	if downloadParam == "" {
-		return "", fmt.Errorf("wechat cdn upload response is missing x-encrypted-param")
-	}
-	log.Printf("im wechat cdn upload succeeded: kind=%s file_key=%s", label, fileKey)
-	return downloadParam, nil
-}
-
-func buildWeChatCDNUploadURL(baseURL string, uploadParam string, fileKey string) string {
-	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
-	if baseURL == "" {
-		baseURL = weChatDefaultCDNBaseURL
-	}
-	return fmt.Sprintf("%s/upload?encrypted_query_param=%s&filekey=%s", baseURL, url.QueryEscape(uploadParam), url.QueryEscape(fileKey))
-}
-
-func mustWeChatHost(rawURL string) string {
-	parsed, err := url.Parse(rawURL)
-	if err != nil {
-		return ""
-	}
-	return parsed.Host
-}
-
-func encryptWeChatAESECB(plaintext []byte, key []byte) ([]byte, error) {
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return nil, fmt.Errorf("create aes cipher: %w", err)
-	}
-	padded := pkcs7Pad(plaintext, block.BlockSize())
-	ciphertext := make([]byte, len(padded))
-	for start := 0; start < len(padded); start += block.BlockSize() {
-		block.Encrypt(ciphertext[start:start+block.BlockSize()], padded[start:start+block.BlockSize()])
-	}
-	return ciphertext, nil
-}
-
-func pkcs7Pad(plaintext []byte, blockSize int) []byte {
-	padding := blockSize - (len(plaintext) % blockSize)
-	if padding == 0 {
-		padding = blockSize
-	}
-	result := make([]byte, len(plaintext)+padding)
-	copy(result, plaintext)
-	for i := len(plaintext); i < len(result); i++ {
-		result[i] = byte(padding)
-	}
-	return result
+	return weChatUploadedImage{
+		FileKey:   uploaded.FileKey,
+		AESKeyHex: uploaded.AESKeyHex,
+		Original:  uploaded.Original,
+	}, nil
 }

--- a/internal/im/wechat_media.go
+++ b/internal/im/wechat_media.go
@@ -1,0 +1,249 @@
+package im
+
+import (
+	"bytes"
+	"context"
+	"crypto/aes"
+	"crypto/md5"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+)
+
+const (
+	weChatUploadMediaTypeImage = 1
+	weChatUploadMediaTypeVideo = 2
+	weChatUploadMediaTypeFile  = 3
+)
+
+type weChatGetUploadURLResponse struct {
+	UploadParam      string `json:"upload_param"`
+	ThumbUploadParam string `json:"thumb_upload_param"`
+	UploadFullURL    string `json:"upload_full_url"`
+}
+
+type weChatUploadedMedia struct {
+	DownloadEncryptedParam string
+	CiphertextBytes        int64
+}
+
+type weChatUploadedAsset struct {
+	FileKey        string
+	AESKeyHex      string
+	PlaintextBytes int64
+	Original       weChatUploadedMedia
+}
+
+type weChatMediaUploadRequest struct {
+	FilePath  string
+	FileName  string
+	MediaType int
+	LogLabel  string
+}
+
+func (a *WeChatAdapter) uploadMediaAsset(ctx context.Context, account Account, target Target, req weChatMediaUploadRequest) (weChatUploadedAsset, error) {
+	content, err := os.ReadFile(req.FilePath)
+	if err != nil {
+		return weChatUploadedAsset{}, fmt.Errorf("read %s file: %w", req.LogLabel, err)
+	}
+	fileKey, err := randomWeChatToken(16)
+	if err != nil {
+		return weChatUploadedAsset{}, err
+	}
+	aesKeyRaw := make([]byte, 16)
+	if _, err := rand.Read(aesKeyRaw); err != nil {
+		return weChatUploadedAsset{}, fmt.Errorf("generate %s aes key: %w", req.LogLabel, err)
+	}
+
+	rawMD5 := md5.Sum(content)
+	ciphertext, err := encryptWeChatAESECB(content, aesKeyRaw)
+	if err != nil {
+		return weChatUploadedAsset{}, err
+	}
+
+	log.Printf("im wechat %s upload start: account=%s target=%s file=%q raw_bytes=%d", req.LogLabel, account.ID, target.ID, req.FileName, len(content))
+
+	aesKeyHex := hex.EncodeToString(aesKeyRaw)
+	uploadMeta, err := a.getUploadURL(ctx, account, target, fileKey, req.MediaType, len(content), hex.EncodeToString(rawMD5[:]), len(ciphertext), aesKeyHex, req.LogLabel)
+	if err != nil {
+		return weChatUploadedAsset{}, err
+	}
+	log.Printf("im wechat %s upload url ready: account=%s target=%s file_key=%s official_flow=true", req.LogLabel, account.ID, target.ID, fileKey)
+
+	downloadParam, err := a.uploadMediaCiphertext(ctx, uploadMeta.UploadFullURL, uploadMeta.UploadParam, fileKey, ciphertext, req.LogLabel)
+	if err != nil {
+		return weChatUploadedAsset{}, err
+	}
+	log.Printf("im wechat %s upload succeeded: account=%s target=%s file=%q file_key=%s encrypted_bytes=%d official_flow=true", req.LogLabel, account.ID, target.ID, req.FileName, fileKey, len(ciphertext))
+
+	return weChatUploadedAsset{
+		FileKey:        fileKey,
+		AESKeyHex:      aesKeyHex,
+		PlaintextBytes: int64(len(content)),
+		Original: weChatUploadedMedia{
+			DownloadEncryptedParam: downloadParam,
+			CiphertextBytes:        int64(len(ciphertext)),
+		},
+	}, nil
+}
+
+func (a *WeChatAdapter) getUploadURL(ctx context.Context, account Account, target Target, fileKey string, mediaType int, rawSize int, rawMD5 string, cipherSize int, aesKeyHex string, logLabel string) (weChatGetUploadURLResponse, error) {
+	log.Printf("im wechat %s upload url request: account=%s target=%s file_key=%s raw_bytes=%d encrypted_bytes=%d official_flow=true", logLabel, account.ID, target.ID, fileKey, rawSize, cipherSize)
+
+	body, err := json.Marshal(map[string]any{
+		"filekey":       fileKey,
+		"media_type":    mediaType,
+		"to_user_id":    target.TargetUserID,
+		"rawsize":       rawSize,
+		"rawfilemd5":    rawMD5,
+		"filesize":      cipherSize,
+		"no_need_thumb": true,
+		"aeskey":        aesKeyHex,
+		"base_info": map[string]any{
+			"channel_version": weChatDefaultChannelLabel,
+		},
+	})
+	if err != nil {
+		return weChatGetUploadURLResponse{}, fmt.Errorf("encode wechat upload url request: %w", err)
+	}
+
+	respBody, err := a.postJSON(ctx, account.BaseURL, "ilink/bot/getuploadurl", account.Token, body)
+	if err != nil {
+		return weChatGetUploadURLResponse{}, err
+	}
+
+	var resp weChatGetUploadURLResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return weChatGetUploadURLResponse{}, fmt.Errorf("decode wechat upload url response: %w", err)
+	}
+	if strings.TrimSpace(resp.UploadFullURL) == "" && strings.TrimSpace(resp.UploadParam) == "" {
+		return weChatGetUploadURLResponse{}, fmt.Errorf("wechat upload url response is missing upload_full_url and upload_param")
+	}
+	return resp, nil
+}
+
+func (a *WeChatAdapter) uploadMediaCiphertext(ctx context.Context, uploadFullURL string, uploadParam string, fileKey string, ciphertext []byte, label string) (string, error) {
+	uploadURL := strings.TrimSpace(uploadFullURL)
+	if uploadURL == "" {
+		uploadURL = buildWeChatCDNUploadURL(a.cdnBaseURL, strings.TrimSpace(uploadParam), fileKey)
+	}
+	log.Printf("im wechat cdn upload start: kind=%s file_key=%s bytes=%d host=%s", label, fileKey, len(ciphertext), mustWeChatHost(uploadURL))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadURL, bytes.NewReader(ciphertext))
+	if err != nil {
+		return "", fmt.Errorf("build wechat cdn upload request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("wechat cdn upload failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read wechat cdn upload response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		message := strings.TrimSpace(resp.Header.Get("x-error-message"))
+		if message == "" {
+			message = strings.TrimSpace(string(respBody))
+		}
+		return "", fmt.Errorf("wechat cdn upload failed: status=%d body=%s", resp.StatusCode, message)
+	}
+
+	downloadParam := strings.TrimSpace(resp.Header.Get("x-encrypted-param"))
+	if downloadParam == "" {
+		return "", fmt.Errorf("wechat cdn upload response is missing x-encrypted-param")
+	}
+	log.Printf("im wechat cdn upload succeeded: kind=%s file_key=%s", label, fileKey)
+	return downloadParam, nil
+}
+
+func (a *WeChatAdapter) sendMediaItem(ctx context.Context, account Account, target Target, itemType int, itemKey string, itemPayload map[string]any) (string, error) {
+	clientID, err := randomWeChatToken(12)
+	if err != nil {
+		return "", err
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"msg": map[string]any{
+			"from_user_id":  "",
+			"to_user_id":    target.TargetUserID,
+			"client_id":     clientID,
+			"message_type":  2,
+			"message_state": 2,
+			"item_list": []map[string]any{
+				{
+					"type":  itemType,
+					itemKey: itemPayload,
+				},
+			},
+		},
+		"base_info": map[string]any{
+			"channel_version": weChatDefaultChannelLabel,
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("encode wechat media message body: %w", err)
+	}
+
+	if _, err := a.postJSON(ctx, account.BaseURL, "ilink/bot/sendmessage", account.Token, body); err != nil {
+		return "", err
+	}
+	return clientID, nil
+}
+
+func encodeWeChatMediaAESKey(aesKeyHex string) string {
+	return base64.StdEncoding.EncodeToString([]byte(strings.TrimSpace(aesKeyHex)))
+}
+
+func buildWeChatCDNUploadURL(baseURL string, uploadParam string, fileKey string) string {
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if baseURL == "" {
+		baseURL = weChatDefaultCDNBaseURL
+	}
+	return fmt.Sprintf("%s/upload?encrypted_query_param=%s&filekey=%s", baseURL, url.QueryEscape(uploadParam), url.QueryEscape(fileKey))
+}
+
+func mustWeChatHost(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	return parsed.Host
+}
+
+func encryptWeChatAESECB(plaintext []byte, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("create aes cipher: %w", err)
+	}
+	padded := pkcs7Pad(plaintext, block.BlockSize())
+	ciphertext := make([]byte, len(padded))
+	for start := 0; start < len(padded); start += block.BlockSize() {
+		block.Encrypt(ciphertext[start:start+block.BlockSize()], padded[start:start+block.BlockSize()])
+	}
+	return ciphertext, nil
+}
+
+func pkcs7Pad(plaintext []byte, blockSize int) []byte {
+	padding := blockSize - (len(plaintext) % blockSize)
+	if padding == 0 {
+		padding = blockSize
+	}
+	result := make([]byte, len(plaintext)+padding)
+	copy(result, plaintext)
+	for i := len(plaintext); i < len(result); i++ {
+		result[i] = byte(padding)
+	}
+	return result
+}

--- a/web/src/components/settings/IMDebugSendPanel.tsx
+++ b/web/src/components/settings/IMDebugSendPanel.tsx
@@ -14,11 +14,20 @@ type Props = {
   imageSending: boolean
   imageFeedback: string | null
   imageError: string | null
+  fileCaption: string
+  fileFileName: string | null
+  fileInputKey: number
+  fileSending: boolean
+  fileFeedback: string | null
+  fileError: string | null
   onTextChange: (value: string) => void
   onSendText: () => void
   onImageCaptionChange: (value: string) => void
   onImageFileChange: (file: File | null) => void
   onSendImage: () => void
+  onFileCaptionChange: (value: string) => void
+  onFileFileChange: (file: File | null) => void
+  onSendFile: () => void
 }
 
 export function IMDebugSendPanel({
@@ -35,11 +44,20 @@ export function IMDebugSendPanel({
   imageSending,
   imageFeedback,
   imageError,
+  fileCaption,
+  fileFileName,
+  fileInputKey,
+  fileSending,
+  fileFeedback,
+  fileError,
   onTextChange,
   onSendText,
   onImageCaptionChange,
   onImageFileChange,
   onSendImage,
+  onFileCaptionChange,
+  onFileFileChange,
+  onSendFile,
 }: Props) {
   const ready = Boolean(account && target)
 
@@ -150,6 +168,47 @@ export function IMDebugSendPanel({
 
         {imageFeedback ? <div className="settings-feedback">{imageFeedback}</div> : null}
         {imageError ? <div className="error-banner settings-error">{imageError}</div> : null}
+
+        <label className="settings-field">
+          <span>测试文件</span>
+          <input
+            className="settings-input"
+            disabled={!ready || fileSending}
+            key={fileInputKey}
+            type="file"
+            onChange={(event) => onFileFileChange(event.target.files?.[0] ?? null)}
+          />
+          <span className="settings-note">
+            {fileFileName ? `已选择：${fileFileName}` : '允许选择任意文件，服务端会先落到媒体缓存目录，再按微信文件消息发送。'}
+          </span>
+        </label>
+
+        <label className="settings-field">
+          <span>文件说明</span>
+          <textarea
+            className="settings-textarea"
+            disabled={!ready || fileSending}
+            placeholder="例如：这是本次调试要发送的文件。"
+            rows={3}
+            value={fileCaption}
+            onChange={(event) => onFileCaptionChange(event.target.value)}
+          />
+        </label>
+
+        <div className="settings-actions">
+          <button
+            className="settings-button"
+            disabled={!ready || fileSending || !fileFileName}
+            onClick={() => onSendFile()}
+            type="button"
+          >
+            {fileSending ? '发送中...' : '发送测试文件'}
+          </button>
+          <span className="settings-note">如果填写了文件说明，微信侧会先收到一条文字，再收到文件。</span>
+        </div>
+
+        {fileFeedback ? <div className="settings-feedback">{fileFeedback}</div> : null}
+        {fileError ? <div className="error-banner settings-error">{fileError}</div> : null}
       </div>
     </article>
   )

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -103,6 +103,12 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
   const [debugImageSending, setDebugImageSending] = useState(false)
   const [debugImageFeedback, setDebugImageFeedback] = useState<string | null>(null)
   const [debugImageError, setDebugImageError] = useState<string | null>(null)
+  const [debugFileFile, setDebugFileFile] = useState<File | null>(null)
+  const [debugFileCaption, setDebugFileCaption] = useState('')
+  const [debugFileInputKey, setDebugFileInputKey] = useState(0)
+  const [debugFileSending, setDebugFileSending] = useState(false)
+  const [debugFileFeedback, setDebugFileFeedback] = useState<string | null>(null)
+  const [debugFileError, setDebugFileError] = useState<string | null>(null)
 
   const [loginPanel, setLoginPanel] = useState<LoginPanelState>(emptyLoginState)
 
@@ -472,6 +478,39 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
     }
   }
 
+  async function sendDebugFile() {
+    if (!debugFileFile) {
+      setDebugFileError('请先选择一个文件。')
+      setDebugFileFeedback(null)
+      return
+    }
+
+    const payload = new FormData()
+    payload.set('file', debugFileFile)
+    payload.set('caption', debugFileCaption)
+
+    setDebugFileSending(true)
+    setDebugFileError(null)
+    setDebugFileFeedback(null)
+    try {
+      const result = await postFormData<{ receipt?: IMDeliveryReceipt }>('/api/im/debug/send-file-default', payload)
+      await refresh()
+      setDebugFileFile(null)
+      setDebugFileCaption('')
+      setDebugFileInputKey((current) => current + 1)
+      if (result.receipt) {
+        const label = result.receipt.media_file_name || debugFileFile.name
+        setDebugFileFeedback(`测试文件 ${label} 已发送到 ${result.receipt.account.display_name || result.receipt.account.remote_account_id} / ${result.receipt.target.name}。`)
+      } else {
+        setDebugFileFeedback('测试文件发送成功。')
+      }
+    } catch (err) {
+      setDebugFileError(err instanceof Error ? err.message : '发送测试文件失败')
+    } finally {
+      setDebugFileSending(false)
+    }
+  }
+
   return (
     <main className="settings-page">
       <section className="settings-hero-card">
@@ -597,11 +636,28 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
                 imageFileName={debugImageFile?.name ?? null}
                 imageInputKey={debugImageInputKey}
                 imageSending={debugImageSending}
+                fileCaption={debugFileCaption}
+                fileError={debugFileError}
+                fileFeedback={debugFileFeedback}
+                fileFileName={debugFileFile?.name ?? null}
+                fileInputKey={debugFileInputKey}
+                fileSending={debugFileSending}
                 target={savedDebugTarget}
                 text={debugText}
                 textError={debugTextError}
                 textFeedback={debugTextFeedback}
                 textSending={debugTextSending}
+                onFileCaptionChange={(value) => {
+                  setDebugFileCaption(value)
+                  setDebugFileFeedback(null)
+                  setDebugFileError(null)
+                }}
+                onFileFileChange={(file) => {
+                  setDebugFileFile(file)
+                  setDebugFileFeedback(null)
+                  setDebugFileError(null)
+                }}
+                onSendFile={() => void sendDebugFile()}
                 onImageCaptionChange={(value) => {
                   setDebugImageCaption(value)
                   setDebugImageFeedback(null)

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -108,7 +108,7 @@ export type IMDeliveryReceipt = {
   account: IMAccount
   target: IMTarget
   message_id: string
-  kind: 'text' | 'image'
+  kind: 'text' | 'image' | 'file'
   text?: string
   caption?: string
   media_file_name?: string


### PR DESCRIPTION
## 变更内容
- 为 IM 网关增加微信文件发送能力，复用现有微信鉴权、getuploadurl、AES 加密和 CDN 上传链路
- 新增默认渠道文件调试接口 `POST /api/im/debug/send-file-default`
- 在设置页的 IM 调试面板增加文件上传与发送入口
- 补充微信文件发送协议测试，并同步更新适配层说明文档

## 说明
- 当前文件发送和图片发送共用一套媒体上传 helper，避免重复维护微信协议细节
- 自动镜像仍然只发送文本；文件发送目前只走默认渠道调试入口

## 验证
- `GOCACHE=$(pwd)/.gocache go test ./...`
- `npm run build:web`
