### PR TITLE
feat: 重构前端控制台体验

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -512,6 +512,16 @@ UI decisions that were explicitly requested:
 - backend logs should live on their own page and not be mixed into `/api/state`
 - dashboard should feel intentional, not generic admin boilerplate
 
+## Frontend UI Style
+
+When modifying XiaoAiAgent frontend pages, always follow the project UI style guide:
+
+- see `docs/frontend-ui-style-guide.md`
+- keep the cute, bright, modern SaaS dashboard style
+- preserve the blue / purple / mint color direction
+- use rounded cards, soft shadows, readable Chinese UI, and light mascot-style decoration
+- do not introduce unrelated visual styles unless the user explicitly asks for a redesign
+
 ## Testing
 
 Recommended Go validation:

--- a/docs/frontend-ui-style-guide.md
+++ b/docs/frontend-ui-style-guide.md
@@ -1,0 +1,190 @@
+# XiaoAiAgent Frontend UI Style Guide
+
+This guide defines the default visual direction for XiaoAiAgent frontend pages.
+
+It should be treated as the baseline style constraint for future Dashboard, Settings, Logs, and other frontend page updates unless the user explicitly asks for a redesign.
+
+The approved Dashboard reference image provided in product discussion is the default visual benchmark for this guide.
+
+## 1. Overall Style Positioning
+
+XiaoAiAgent frontend pages should follow this default style direction:
+
+- modern SaaS dashboard
+- cute technology feel
+- bright and clean
+- rounded card-based layout
+- light robot mascot decoration
+- blue / purple / mint as the main color direction
+- professional but not cold
+- Chinese-first interface
+- moderate information density
+
+This direction applies to:
+
+- Dashboard
+- Settings
+- Logs
+- future management pages
+
+Future frontend changes should extend this language instead of introducing a conflicting visual system.
+
+## 2. Visual Baseline
+
+The current approved Dashboard reference establishes these baseline characteristics:
+
+- fixed left navigation
+- large title area with summary metrics
+- clear multi-card content layout
+- white or near-white cards over a soft bright background
+- soft shadows instead of heavy borders
+- light mascot and decorative technology elements
+- readable Chinese labels with clear hierarchy
+
+When implementing new pages, use this baseline as the first reference before inventing new layout or styling patterns.
+
+## 3. Page Layout Constraints
+
+Dashboard-style pages should follow these layout rules:
+
+- use a fixed or visually stable left navigation bar
+- keep a top title and status summary area
+- use a multi-card layout for the main content area
+- split information into clear functional regions
+- maintain comfortable spacing between cards
+- avoid heavy border boxes
+- prefer soft shadows and subtle light borders
+- keep the full page bright, light, and clean
+
+Typical Dashboard homepage structure:
+
+- left navigation: Logo, Dashboard, Settings, Logs, user info
+- top area: page title, service status, task metrics, refresh status
+- left main card: task list
+- center main card: task details, progress, summary
+- right card stack: event flow, Artifacts, Claude record, recent conversation
+
+Settings and Logs pages should preserve the same shell and card rhythm even when the content differs.
+
+## 4. Color Constraints
+
+Recommended color direction:
+
+- primary color: blue
+- secondary colors: purple and mint
+- success state: green
+- failure state: red, but softened
+- canceled / neutral state: gray or soft purple-gray
+- page background: light blue-white, light gray-white, or subtle soft gradient
+- cards: white or near-white
+- decoration: low-saturation pastel colors
+
+Avoid:
+
+- large dark backgrounds
+- neon colors
+- heavy black borders
+- cold enterprise-gray admin styling
+- overly decorative visuals that reduce readability
+
+## 5. Component Style Constraints
+
+Buttons, cards, inputs, selects, tabs, tables, and status labels should follow these rules:
+
+- large rounded corners
+- light shadow treatment
+- thin borders or visually subtle borders
+- soft hover states
+- pill-style status badges
+- linear or light semi-skeuomorphic icon style
+- lists and tables should remain clean and well-separated
+
+Common status color expectations:
+
+- running: blue
+- completed: green
+- failed: red
+- canceled: gray or purple-gray
+- service healthy: green
+
+Interactive controls should feel polished and friendly, not like raw browser defaults or engineering-only console widgets.
+
+## 6. Illustration and Decoration Constraints
+
+Allowed decorative elements:
+
+- cute AI robot mascot
+- small stars
+- clouds
+- soft dots
+- small technology-themed icons
+- low-contrast gradient blocks
+
+Rules:
+
+- decoration must not cover content
+- decoration must not reduce readability
+- mascot should feel cute, friendly, and lightly technological
+- illustration is supporting material, not the main content
+- product information always has priority over decoration
+
+Do not remove mascot-style brand recognition without an explicit request.
+
+## 7. Typography and Layout Density
+
+- Chinese UI comes first
+- headings should be clear and strongly hierarchical
+- body text should stay readable
+- time, ID, and status information should align clearly
+- avoid font sizes that are too small for a management page
+- avoid cramped card content
+- keep card copy concise and scannable
+
+The dashboard should feel informative, not crowded.
+
+## 8. Rules for Future Frontend Changes
+
+Any future frontend UI change must follow this order:
+
+1. read this style guide first
+2. preserve consistency across Dashboard, Settings, and Logs
+3. reuse existing shell, card, status badge, spacing, and color patterns
+4. extend the existing design language instead of replacing it
+
+When adding new pages or sections:
+
+- reuse the existing overall page shell
+- reuse rounded cards and soft status badges
+- stay within the blue / purple / mint direction
+- keep Chinese labels readable and product-oriented
+- keep the cute technology branding visible but restrained
+
+Unless the user explicitly asks for a redesign:
+
+- do not radically change the overall visual language
+- do not replace the shell with a totally different admin framework style
+- do not turn the interface into a raw engineering control panel
+
+## 9. Things That Should Not Be Done
+
+Explicitly disallowed by default:
+
+- turning the UI into a dark hacker style
+- turning the UI into a traditional Bootstrap admin style
+- turning the UI into a minimal no-brand style
+- using too many strong gradients
+- using busy backgrounds that reduce readability
+- removing mascot / cute technology decoration without request
+- changing the main layout structure without request
+
+## 10. Implementation Notes
+
+This guide is about visual and interaction style constraints.
+
+It does not require:
+
+- changing backend APIs
+- rewriting page business logic
+- introducing runtime dependency on the reference image
+
+If a future change needs a major redesign, that redesign should first update this guide or explicitly state why it is intentionally diverging.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1673,6 +1673,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmmirror.com/lucide-react/-/lucide-react-1.11.0.tgz",
+      "integrity": "sha512-UOhjdztXCgdBReRcIhsvz2siIBogfv/lhJEIViCpLt924dO+GDms9T7DNoucI23s6kEPpe988m5N0D2ajnzb2g==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz",
@@ -2160,6 +2169,7 @@
       "name": "open-xiaoai-agent-web",
       "version": "0.0.0",
       "dependencies": {
+        "lucide-react": "^1.11.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },

--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>XiaoAiAgent Dashboard</title>
+    <title>XiaoAiAgent 控制台</title>
   </head>
   <body>
     <div id="root"></div>

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "lucide-react": "^1.11.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,28 +11,30 @@ export default function App() {
 
   return (
     <div className="app-shell">
-      <div className="aurora aurora-left" />
-      <div className="aurora aurora-right" />
+      <div className="app-glow app-glow-left" />
+      <div className="app-glow app-glow-right" />
 
-      <AppTopbar page={page} />
+      <AppTopbar data={data} page={page} />
 
-      {page === 'dashboard' ? (
-        <DashboardPage
-          data={data}
-          error={error}
-          loading={loading}
-          setData={setData}
-        />
-      ) : page === 'logs' ? (
-        <LogsPage />
-      ) : (
-        <SettingsPage
-          data={data}
-          error={error}
-          refresh={refresh}
-          setData={setData}
-        />
-      )}
+      <div className="app-main">
+        {page === 'dashboard' ? (
+          <DashboardPage
+            data={data}
+            error={error}
+            loading={loading}
+            setData={setData}
+          />
+        ) : page === 'logs' ? (
+          <LogsPage />
+        ) : (
+          <SettingsPage
+            data={data}
+            error={error}
+            refresh={refresh}
+            setData={setData}
+          />
+        )}
+      </div>
     </div>
   )
 }

--- a/web/src/components/AppTopbar.tsx
+++ b/web/src/components/AppTopbar.tsx
@@ -1,28 +1,67 @@
+import { BellRing, LayoutDashboard, Settings2, Sparkles, TextSearch } from 'lucide-react'
+import type { DashboardState } from '../types'
 import type { Page } from '../lib/dashboard'
 
 type Props = {
   page: Page
+  data: DashboardState
 }
 
-export function AppTopbar({ page }: Props) {
+const navItems: Array<{ key: Page; href: string; label: string; caption: string; Icon: typeof LayoutDashboard }> = [
+  { key: 'dashboard', href: '#/', label: '任务看板', caption: '对话、任务、交付', Icon: LayoutDashboard },
+  { key: 'settings', href: '#/settings', label: '系统设置', caption: '镜像、账号、调试', Icon: Settings2 },
+  { key: 'logs', href: '#/logs', label: '后端日志', caption: '排查与追踪', Icon: TextSearch },
+]
+
+export function AppTopbar({ page, data }: Props) {
+  const pendingCount = data.tasks.filter((task) => task.report_pending).length
+  const runningCount = data.tasks.filter((task) => task.state === 'running').length
+
   return (
-    <header className="topbar">
-      <div>
-        <p className="eyebrow">XIAOAIAGENT</p>
-        <h1 className="topbar-title">XiaoAiAgent 控制台</h1>
+    <aside className="app-sidebar">
+      <div className="brand-card">
+        <div className="brand-orb brand-orb-peach" />
+        <div className="brand-orb brand-orb-mint" />
+        <p className="brand-kicker">XIAOAIAGENT</p>
+        <h1>更可爱一点的小爱工作台</h1>
+        <p>
+          把聊天、复杂任务、交付文件和默认触达都收在一个安静、清爽又更顺手的界面里。
+        </p>
       </div>
 
-      <nav className="topbar-nav">
-        <a className={`topbar-link ${page === 'dashboard' ? 'topbar-link-active' : ''}`} href="#/">
-          任务看板
-        </a>
-        <a className={`topbar-link ${page === 'settings' ? 'topbar-link-active' : ''}`} href="#/settings">
-          系统设置
-        </a>
-        <a className={`topbar-link ${page === 'logs' ? 'topbar-link-active' : ''}`} href="#/logs">
-          后端日志
-        </a>
+      <nav className="sidebar-nav">
+        {navItems.map(({ key, href, label, caption, Icon }) => {
+          const active = key === page
+          return (
+            <a className={`sidebar-link ${active ? 'sidebar-link-active' : ''}`} href={href} key={key}>
+              <span className="sidebar-link-icon">
+                <Icon size={18} />
+              </span>
+              <span className="sidebar-link-copy">
+                <strong>{label}</strong>
+                <small>{caption}</small>
+              </span>
+            </a>
+          )
+        })}
       </nav>
-    </header>
+
+      <div className="sidebar-stats">
+        <article className="mini-stat mini-stat-peach">
+          <span>
+            <Sparkles size={14} />
+            待补报
+          </span>
+          <strong>{pendingCount}</strong>
+        </article>
+        <article className="mini-stat mini-stat-mint">
+          <span>
+            <BellRing size={14} />
+            执行中
+          </span>
+          <strong>{runningCount}</strong>
+        </article>
+      </div>
+    </aside>
   )
 }

--- a/web/src/components/AppTopbar.tsx
+++ b/web/src/components/AppTopbar.tsx
@@ -1,4 +1,4 @@
-import { BellRing, LayoutDashboard, Settings2, Sparkles, TextSearch } from 'lucide-react'
+import { Bot, ChevronRight, LayoutDashboard, Settings2, TextSearch } from 'lucide-react'
 import type { DashboardState } from '../types'
 import type { Page } from '../lib/dashboard'
 
@@ -7,30 +7,33 @@ type Props = {
   data: DashboardState
 }
 
-const navItems: Array<{ key: Page; href: string; label: string; caption: string; Icon: typeof LayoutDashboard }> = [
-  { key: 'dashboard', href: '#/', label: '任务看板', caption: '对话、任务、交付', Icon: LayoutDashboard },
-  { key: 'settings', href: '#/settings', label: '系统设置', caption: '镜像、账号、调试', Icon: Settings2 },
-  { key: 'logs', href: '#/logs', label: '后端日志', caption: '排查与追踪', Icon: TextSearch },
+const navItems: Array<{ key: Page; href: string; label: string; Icon: typeof LayoutDashboard }> = [
+  { key: 'dashboard', href: '#/', label: 'Dashboard', Icon: LayoutDashboard },
+  { key: 'settings', href: '#/settings', label: 'Settings', Icon: Settings2 },
+  { key: 'logs', href: '#/logs', label: 'Logs', Icon: TextSearch },
 ]
 
-export function AppTopbar({ page, data }: Props) {
-  const pendingCount = data.tasks.filter((task) => task.report_pending).length
-  const runningCount = data.tasks.filter((task) => task.state === 'running').length
-
+export function AppTopbar({ page, data: _data }: Props) {
   return (
     <aside className="app-sidebar">
-      <div className="brand-card">
-        <div className="brand-orb brand-orb-peach" />
-        <div className="brand-orb brand-orb-mint" />
-        <p className="brand-kicker">XIAOAIAGENT</p>
-        <h1>更可爱一点的小爱工作台</h1>
-        <p>
-          把聊天、复杂任务、交付文件和默认触达都收在一个安静、清爽又更顺手的界面里。
-        </p>
+      <div className="sidebar-brand">
+        <div className="sidebar-brand-mark">
+          <div className="sidebar-logo-shell">
+            <div className="sidebar-logo-face">
+              <Bot size={18} />
+            </div>
+            <span className="sidebar-logo-dot sidebar-logo-dot-top" />
+            <span className="sidebar-logo-dot sidebar-logo-dot-bottom" />
+          </div>
+        </div>
+        <div className="sidebar-brand-copy">
+          <strong>XiaoAiAgent</strong>
+          <small>Frontend Console</small>
+        </div>
       </div>
 
       <nav className="sidebar-nav">
-        {navItems.map(({ key, href, label, caption, Icon }) => {
+        {navItems.map(({ key, href, label, Icon }) => {
           const active = key === page
           return (
             <a className={`sidebar-link ${active ? 'sidebar-link-active' : ''}`} href={href} key={key}>
@@ -39,28 +42,36 @@ export function AppTopbar({ page, data }: Props) {
               </span>
               <span className="sidebar-link-copy">
                 <strong>{label}</strong>
-                <small>{caption}</small>
               </span>
             </a>
           )
         })}
       </nav>
 
-      <div className="sidebar-stats">
-        <article className="mini-stat mini-stat-peach">
-          <span>
-            <Sparkles size={14} />
-            待补报
-          </span>
-          <strong>{pendingCount}</strong>
-        </article>
-        <article className="mini-stat mini-stat-mint">
-          <span>
-            <BellRing size={14} />
-            执行中
-          </span>
-          <strong>{runningCount}</strong>
-        </article>
+      <div className="sidebar-mascot-card">
+        <div className="sidebar-mascot-stars">
+          <span />
+          <span />
+          <span />
+        </div>
+        <div className="sidebar-mascot-floor" />
+        <div className="sidebar-mascot-bot">
+          <div className="sidebar-mascot-antenna" />
+          <div className="sidebar-mascot-head">
+            <span className="sidebar-mascot-eye" />
+            <span className="sidebar-mascot-eye" />
+          </div>
+          <div className="sidebar-mascot-body" />
+        </div>
+      </div>
+
+      <div className="sidebar-user-card">
+        <div className="sidebar-user-avatar">管</div>
+        <div className="sidebar-user-copy">
+          <strong>管理员</strong>
+          <small>admin@xiaoaiagent.local</small>
+        </div>
+        <ChevronRight size={16} />
       </div>
     </aside>
   )

--- a/web/src/components/dashboard/ConversationPane.tsx
+++ b/web/src/components/dashboard/ConversationPane.tsx
@@ -1,0 +1,46 @@
+import { MessageCircleHeart } from 'lucide-react'
+import { formatTime } from '../../lib/dashboard'
+import type { ConversationSnapshot } from '../../types'
+import { EmptyState } from '../ui/EmptyState'
+import { SectionCard } from '../ui/SectionCard'
+
+type Props = {
+  conversation: ConversationSnapshot | null
+}
+
+export function ConversationPane({ conversation }: Props) {
+  return (
+    <SectionCard
+      className="conversation-card"
+      description="这里保留最近一次正在延续的对话片段，方便确认小爱刚刚记住了什么。"
+      eyebrow="CHAT MEMORY"
+      title="最近会话"
+    >
+      {!conversation ? (
+        <EmptyState title="还没有活跃会话" description="等你和小爱多说几句，这里就会开始积累最近上下文。" />
+      ) : (
+        <div className="conversation-stack">
+          <div className="conversation-summary">
+            <span>
+              <MessageCircleHeart size={14} />
+              {conversation.messages.length} 条消息
+            </span>
+            <span>{formatTime(conversation.last_active)}</span>
+          </div>
+
+          <div className="conversation-bubbles">
+            {conversation.messages.map((message, index) => (
+              <article
+                className={`chat-bubble ${message.role === 'user' ? 'chat-bubble-user' : 'chat-bubble-assistant'}`}
+                key={`${conversation.id}-${index}`}
+              >
+                <strong>{message.role === 'user' ? '你' : '小爱'}</strong>
+                <p>{message.content}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      )}
+    </SectionCard>
+  )
+}

--- a/web/src/components/dashboard/TaskDetailPane.tsx
+++ b/web/src/components/dashboard/TaskDetailPane.tsx
@@ -1,0 +1,188 @@
+import { Bot, Download, FileHeart, FolderCog, ScrollText } from 'lucide-react'
+import { formatBytes, formatTime } from '../../lib/dashboard'
+import type { ClaudeRecord, Task, TaskArtifact, TaskEvent } from '../../types'
+import { EmptyState } from '../ui/EmptyState'
+import { PillTabs } from '../ui/PillTabs'
+import { SectionCard } from '../ui/SectionCard'
+import { StatusBadge } from '../ui/StatusBadge'
+
+export type TaskDetailTab = 'overview' | 'artifacts' | 'events' | 'claude'
+
+type Props = {
+  task: Task | null
+  artifacts: TaskArtifact[]
+  events: TaskEvent[]
+  claudeRecord: ClaudeRecord | null
+  tab: TaskDetailTab
+  onTabChange: (tab: TaskDetailTab) => void
+}
+
+const tabs: Array<{ key: TaskDetailTab; label: string; caption: string }> = [
+  { key: 'overview', label: '概览', caption: '摘要与结果' },
+  { key: 'artifacts', label: '产物', caption: '文件与下载' },
+  { key: 'events', label: '轨迹', caption: '过程记录' },
+  { key: 'claude', label: '执行器', caption: 'Claude 上下文' },
+]
+
+export function TaskDetailPane({ task, artifacts, events, claudeRecord, tab, onTabChange }: Props) {
+  if (!task) {
+    return (
+      <SectionCard
+        className="dashboard-main-card"
+        description="选中一条任务之后，可以在这里继续看它的过程、结果和交付文件。"
+        eyebrow="TASK ROOM"
+        title="任务工作台"
+      >
+        <EmptyState title="先选一条任务" description="左边点开任意一条任务，这里就会展开更完整的细节。" />
+      </SectionCard>
+    )
+  }
+
+  return (
+    <SectionCard
+      actions={<StatusBadge state={task.state} />}
+      className="dashboard-main-card"
+      description={task.input || '这条任务没有额外输入描述。'}
+      eyebrow="TASK ROOM"
+      title={task.title}
+    >
+      <PillTabs tabs={tabs} value={tab} onChange={onTabChange} />
+
+      {tab === 'overview' ? (
+        <div className="detail-grid">
+          <article className="soft-panel">
+            <div className="soft-panel-head">
+              <ScrollText size={18} />
+              <strong>阶段摘要</strong>
+            </div>
+            <p>{task.summary || '当前还没有阶段摘要。'}</p>
+          </article>
+
+          <article className="soft-panel">
+            <div className="soft-panel-head">
+              <Bot size={18} />
+              <strong>最终结果</strong>
+            </div>
+            <p>{task.result || '任务还没有给出最终结果。'}</p>
+          </article>
+
+          <article className="soft-panel">
+            <div className="soft-panel-head">
+              <FolderCog size={18} />
+              <strong>基础信息</strong>
+            </div>
+            <dl className="fact-list">
+              <div>
+                <dt>任务 ID</dt>
+                <dd>{task.id}</dd>
+              </div>
+              <div>
+                <dt>类型</dt>
+                <dd>{task.kind}</dd>
+              </div>
+              <div>
+                <dt>创建时间</dt>
+                <dd>{formatTime(task.created_at)}</dd>
+              </div>
+              <div>
+                <dt>最近更新</dt>
+                <dd>{formatTime(task.updated_at)}</dd>
+              </div>
+            </dl>
+          </article>
+        </div>
+      ) : null}
+
+      {tab === 'artifacts' ? (
+        artifacts.length > 0 ? (
+          <div className="artifact-list">
+            {artifacts.map((artifact) => (
+              <article className="artifact-card" key={artifact.id}>
+                <div className="artifact-card-head">
+                  <div className="artifact-card-copy">
+                    <strong>{artifact.file_name}</strong>
+                    <p>{artifact.mime_type || 'application/octet-stream'}</p>
+                  </div>
+                  {artifact.deliver ? <span className="soft-chip soft-chip-peach">已标记交付</span> : null}
+                </div>
+                <div className="artifact-card-meta">
+                  <span>
+                    <FileHeart size={14} />
+                    {artifact.kind}
+                  </span>
+                  <span>{formatBytes(artifact.size_bytes)}</span>
+                  <span>{formatTime(artifact.created_at)}</span>
+                </div>
+                <a
+                  className="action-link"
+                  href={`/api/tasks/${encodeURIComponent(artifact.task_id)}/artifacts/${encodeURIComponent(artifact.id)}/download`}
+                >
+                  <Download size={16} />
+                  下载这个产物
+                </a>
+              </article>
+            ))}
+          </div>
+        ) : (
+          <EmptyState title="还没有交付文件" description="如果这条任务产出了网页、文档或别的文件，它们会在这里出现。" />
+        )
+      ) : null}
+
+      {tab === 'events' ? (
+        events.length > 0 ? (
+          <div className="timeline-stack">
+            {events.map((event) => (
+              <article className="timeline-bubble" key={event.id}>
+                <div className="timeline-bubble-head">
+                  <strong>{event.type}</strong>
+                  <span>{formatTime(event.created_at)}</span>
+                </div>
+                <p>{event.message}</p>
+              </article>
+            ))}
+          </div>
+        ) : (
+          <EmptyState title="过程记录还很安静" description="这条任务目前还没有额外事件，稍后会在这里看到更多过程信息。" />
+        )
+      ) : null}
+
+      {tab === 'claude' ? (
+        claudeRecord ? (
+          <div className="detail-grid">
+            <article className="soft-panel">
+              <div className="soft-panel-head">
+                <Bot size={18} />
+                <strong>会话与状态</strong>
+              </div>
+              <dl className="fact-list">
+                <div>
+                  <dt>Claude 会话</dt>
+                  <dd>{claudeRecord.session_id || '还未建立'}</dd>
+                </div>
+                <div>
+                  <dt>执行状态</dt>
+                  <dd>{claudeRecord.status}</dd>
+                </div>
+                <div>
+                  <dt>工作目录</dt>
+                  <dd>{claudeRecord.working_directory || '—'}</dd>
+                </div>
+              </dl>
+            </article>
+
+            <article className="soft-panel">
+              <div className="soft-panel-head">
+                <ScrollText size={18} />
+                <strong>最近进度</strong>
+              </div>
+              <p>{claudeRecord.last_summary || '还没有可展示的执行摘要。'}</p>
+              {claudeRecord.error ? <p className="inline-error">{claudeRecord.error}</p> : null}
+            </article>
+          </div>
+        ) : (
+          <EmptyState title="这条任务没有 Claude 私有记录" description="如果它是通过 Claude Code 执行的，这里会展示会话和工作目录信息。" />
+        )
+      ) : null}
+    </SectionCard>
+  )
+}

--- a/web/src/components/dashboard/TaskDetailPane.tsx
+++ b/web/src/components/dashboard/TaskDetailPane.tsx
@@ -1,188 +1,224 @@
-import { Bot, Download, FileHeart, FolderCog, ScrollText } from 'lucide-react'
-import { formatBytes, formatTime } from '../../lib/dashboard'
+import { Bot, CalendarClock, FileStack, FolderTree, Sparkles, TimerReset } from 'lucide-react'
+import { formatTime } from '../../lib/dashboard'
 import type { ClaudeRecord, Task, TaskArtifact, TaskEvent } from '../../types'
 import { EmptyState } from '../ui/EmptyState'
-import { PillTabs } from '../ui/PillTabs'
 import { SectionCard } from '../ui/SectionCard'
 import { StatusBadge } from '../ui/StatusBadge'
 
-export type TaskDetailTab = 'overview' | 'artifacts' | 'events' | 'claude'
-
 type Props = {
   task: Task | null
-  artifacts: TaskArtifact[]
   events: TaskEvent[]
+  artifacts: TaskArtifact[]
   claudeRecord: ClaudeRecord | null
-  tab: TaskDetailTab
-  onTabChange: (tab: TaskDetailTab) => void
 }
 
-const tabs: Array<{ key: TaskDetailTab; label: string; caption: string }> = [
-  { key: 'overview', label: '概览', caption: '摘要与结果' },
-  { key: 'artifacts', label: '产物', caption: '文件与下载' },
-  { key: 'events', label: '轨迹', caption: '过程记录' },
-  { key: 'claude', label: '执行器', caption: 'Claude 上下文' },
-]
+type ProgressModel = {
+  percent: number
+  step: number
+  steps: Array<{ label: string; note: string; done: boolean; active: boolean }>
+}
 
-export function TaskDetailPane({ task, artifacts, events, claudeRecord, tab, onTabChange }: Props) {
+function buildProgressModel(task: Task, events: TaskEvent[], artifacts: TaskArtifact[]): ProgressModel {
+  const hasArtifacts = artifacts.length > 0
+  const eventCount = events.length
+
+  if (task.state === 'completed') {
+    return {
+      percent: 100,
+      step: 5,
+      steps: [
+        { label: '已接收', note: formatTime(task.created_at), done: true, active: false },
+        { label: '开始执行', note: eventCount > 0 ? formatTime(events[0]?.created_at ?? task.created_at) : '已开始', done: true, active: false },
+        { label: '处理中', note: task.summary ? '阶段摘要已生成' : '处理中', done: true, active: false },
+        { label: '生成产物', note: hasArtifacts ? `${artifacts.length} 个产物` : '无需产物', done: true, active: false },
+        { label: '完成', note: formatTime(task.updated_at), done: true, active: true },
+      ],
+    }
+  }
+
+  if (task.state === 'failed' || task.state === 'canceled') {
+    return {
+      percent: hasArtifacts ? 76 : eventCount >= 2 ? 54 : 28,
+      step: hasArtifacts ? 4 : eventCount >= 2 ? 3 : 2,
+      steps: [
+        { label: '已接收', note: formatTime(task.created_at), done: true, active: false },
+        { label: '开始执行', note: eventCount > 0 ? formatTime(events[0]?.created_at ?? task.created_at) : '已开始', done: true, active: false },
+        { label: '处理中', note: task.state === 'failed' ? '任务异常结束' : '任务被取消', done: eventCount >= 2, active: eventCount < 2 },
+        { label: '生成产物', note: hasArtifacts ? `${artifacts.length} 个产物` : '未生成', done: hasArtifacts, active: eventCount >= 2 && !hasArtifacts },
+        { label: '完成', note: '未达成', done: false, active: false },
+      ],
+    }
+  }
+
+  if (task.state === 'running') {
+    const step = hasArtifacts ? 4 : eventCount >= 2 ? 3 : 2
+    const percent = hasArtifacts ? 78 : eventCount >= 2 ? 62 : 36
+    return {
+      percent,
+      step,
+      steps: [
+        { label: '已接收', note: formatTime(task.created_at), done: true, active: false },
+        { label: '开始执行', note: eventCount > 0 ? formatTime(events[0]?.created_at ?? task.created_at) : '已开始', done: true, active: false },
+        { label: '处理中', note: task.summary || '正在推进当前任务', done: step > 3, active: step === 3 },
+        { label: '生成产物', note: hasArtifacts ? `${artifacts.length} 个产物已写入` : '待产物输出', done: false, active: step === 4 },
+        { label: '完成', note: '等待结束', done: false, active: false },
+      ],
+    }
+  }
+
+  return {
+    percent: 18,
+    step: 1,
+    steps: [
+      { label: '已接收', note: formatTime(task.created_at), done: true, active: true },
+      { label: '开始执行', note: '等待调度', done: false, active: false },
+      { label: '处理中', note: '等待推进', done: false, active: false },
+      { label: '生成产物', note: '待开始', done: false, active: false },
+      { label: '完成', note: '待开始', done: false, active: false },
+    ],
+  }
+}
+
+export function TaskDetailPane({ task, events, artifacts, claudeRecord }: Props) {
   if (!task) {
     return (
       <SectionCard
         className="dashboard-main-card"
-        description="选中一条任务之后，可以在这里继续看它的过程、结果和交付文件。"
-        eyebrow="TASK ROOM"
-        title="任务工作台"
+        description="选中一条任务之后，这里会展示它的状态、摘要、执行节奏和当前上下文。"
+        eyebrow="TASK DETAIL"
+        title="任务详情"
       >
-        <EmptyState title="先选一条任务" description="左边点开任意一条任务，这里就会展开更完整的细节。" />
+        <EmptyState title="先选一条任务" description="左侧点开任意任务，这里就会展开完整细节。" />
       </SectionCard>
     )
   }
+
+  const progress = buildProgressModel(task, events, artifacts)
 
   return (
     <SectionCard
       actions={<StatusBadge state={task.state} />}
       className="dashboard-main-card"
       description={task.input || '这条任务没有额外输入描述。'}
-      eyebrow="TASK ROOM"
+      eyebrow="TASK DETAIL"
       title={task.title}
     >
-      <PillTabs tabs={tabs} value={tab} onChange={onTabChange} />
-
-      {tab === 'overview' ? (
-        <div className="detail-grid">
-          <article className="soft-panel">
-            <div className="soft-panel-head">
-              <ScrollText size={18} />
-              <strong>阶段摘要</strong>
-            </div>
-            <p>{task.summary || '当前还没有阶段摘要。'}</p>
-          </article>
-
-          <article className="soft-panel">
-            <div className="soft-panel-head">
-              <Bot size={18} />
-              <strong>最终结果</strong>
-            </div>
-            <p>{task.result || '任务还没有给出最终结果。'}</p>
-          </article>
-
-          <article className="soft-panel">
-            <div className="soft-panel-head">
-              <FolderCog size={18} />
-              <strong>基础信息</strong>
-            </div>
-            <dl className="fact-list">
-              <div>
-                <dt>任务 ID</dt>
-                <dd>{task.id}</dd>
-              </div>
-              <div>
-                <dt>类型</dt>
-                <dd>{task.kind}</dd>
-              </div>
-              <div>
-                <dt>创建时间</dt>
-                <dd>{formatTime(task.created_at)}</dd>
-              </div>
-              <div>
-                <dt>最近更新</dt>
-                <dd>{formatTime(task.updated_at)}</dd>
-              </div>
-            </dl>
-          </article>
+      <div className="task-detail-hero">
+        <div className="task-detail-meta-grid">
+          <div className="task-detail-meta">
+            <span>任务 ID</span>
+            <p>{task.id}</p>
+          </div>
+          <div className="task-detail-meta">
+            <span>父任务 ID</span>
+            <p>{task.parent_task_id || '—'}</p>
+          </div>
+          <div className="task-detail-meta">
+            <span>Claude 会话</span>
+            <p>{claudeRecord?.session_id || '尚未建立'}</p>
+          </div>
+          <div className="task-detail-meta">
+            <span>任务类型</span>
+            <p>{task.kind}</p>
+          </div>
+          <div className="task-detail-meta">
+            <span>创建时间</span>
+            <p>{formatTime(task.created_at)}</p>
+          </div>
+          <div className="task-detail-meta">
+            <span>最近更新</span>
+            <p>{formatTime(task.updated_at)}</p>
+          </div>
         </div>
-      ) : null}
 
-      {tab === 'artifacts' ? (
-        artifacts.length > 0 ? (
-          <div className="artifact-list">
-            {artifacts.map((artifact) => (
-              <article className="artifact-card" key={artifact.id}>
-                <div className="artifact-card-head">
-                  <div className="artifact-card-copy">
-                    <strong>{artifact.file_name}</strong>
-                    <p>{artifact.mime_type || 'application/octet-stream'}</p>
-                  </div>
-                  {artifact.deliver ? <span className="soft-chip soft-chip-peach">已标记交付</span> : null}
-                </div>
-                <div className="artifact-card-meta">
-                  <span>
-                    <FileHeart size={14} />
-                    {artifact.kind}
-                  </span>
-                  <span>{formatBytes(artifact.size_bytes)}</span>
-                  <span>{formatTime(artifact.created_at)}</span>
-                </div>
-                <a
-                  className="action-link"
-                  href={`/api/tasks/${encodeURIComponent(artifact.task_id)}/artifacts/${encodeURIComponent(artifact.id)}/download`}
-                >
-                  <Download size={16} />
-                  下载这个产物
-                </a>
-              </article>
-            ))}
+        <div className="task-detail-mascot">
+          <div className="task-detail-mascot-ring" />
+          <div className="task-detail-mascot-core">
+            <Bot size={34} />
           </div>
-        ) : (
-          <EmptyState title="还没有交付文件" description="如果这条任务产出了网页、文档或别的文件，它们会在这里出现。" />
-        )
-      ) : null}
+          <span className="task-detail-star task-detail-star-a">
+            <Sparkles size={14} />
+          </span>
+          <span className="task-detail-star task-detail-star-b">
+            <Sparkles size={12} />
+          </span>
+        </div>
+      </div>
 
-      {tab === 'events' ? (
-        events.length > 0 ? (
-          <div className="timeline-stack">
-            {events.map((event) => (
-              <article className="timeline-bubble" key={event.id}>
-                <div className="timeline-bubble-head">
-                  <strong>{event.type}</strong>
-                  <span>{formatTime(event.created_at)}</span>
-                </div>
-                <p>{event.message}</p>
-              </article>
-            ))}
+      <article className="task-progress-card">
+        <div className="task-progress-head">
+          <div>
+            <strong>进度概览</strong>
+            <p>根据当前任务状态、事件和产物数量推导出当前推进阶段。</p>
           </div>
-        ) : (
-          <EmptyState title="过程记录还很安静" description="这条任务目前还没有额外事件，稍后会在这里看到更多过程信息。" />
-        )
-      ) : null}
+          <div className="task-progress-value">
+            <span>总体进度</span>
+            <strong>{progress.percent}%</strong>
+          </div>
+        </div>
 
-      {tab === 'claude' ? (
-        claudeRecord ? (
-          <div className="detail-grid">
-            <article className="soft-panel">
-              <div className="soft-panel-head">
-                <Bot size={18} />
-                <strong>会话与状态</strong>
+        <div className="task-progress-bar">
+          <span style={{ width: `${progress.percent}%` }} />
+        </div>
+
+        <div className="task-progress-steps">
+          {progress.steps.map((step, index) => (
+            <div className="task-progress-step" key={step.label}>
+              <div className={`task-progress-node ${step.done ? 'task-progress-node-done' : ''} ${step.active ? 'task-progress-node-active' : ''}`}>
+                {index + 1}
               </div>
-              <dl className="fact-list">
-                <div>
-                  <dt>Claude 会话</dt>
-                  <dd>{claudeRecord.session_id || '还未建立'}</dd>
-                </div>
-                <div>
-                  <dt>执行状态</dt>
-                  <dd>{claudeRecord.status}</dd>
-                </div>
-                <div>
-                  <dt>工作目录</dt>
-                  <dd>{claudeRecord.working_directory || '—'}</dd>
-                </div>
-              </dl>
-            </article>
-
-            <article className="soft-panel">
-              <div className="soft-panel-head">
-                <ScrollText size={18} />
-                <strong>最近进度</strong>
+              <div className="task-progress-copy">
+                <strong>{step.label}</strong>
+                <span>{step.note}</span>
               </div>
-              <p>{claudeRecord.last_summary || '还没有可展示的执行摘要。'}</p>
-              {claudeRecord.error ? <p className="inline-error">{claudeRecord.error}</p> : null}
-            </article>
+            </div>
+          ))}
+        </div>
+      </article>
+
+      <div className="task-detail-bottom-grid">
+        <article className="task-detail-panel">
+          <div className="task-detail-panel-head">
+            <FolderTree size={16} />
+            <strong>任务说明</strong>
           </div>
-        ) : (
-          <EmptyState title="这条任务没有 Claude 私有记录" description="如果它是通过 Claude Code 执行的，这里会展示会话和工作目录信息。" />
-        )
-      ) : null}
+          <p>{task.input || '这条任务没有额外输入描述。'}</p>
+        </article>
+
+        <article className="task-detail-panel">
+          <div className="task-detail-panel-head">
+            <FileStack size={16} />
+            <strong>当前摘要</strong>
+          </div>
+          <p>{task.summary || '当前还没有阶段摘要。'}</p>
+        </article>
+
+        <article className="task-detail-panel task-detail-panel-wide">
+          <div className="task-detail-panel-head">
+            <CalendarClock size={16} />
+            <strong>最近结果</strong>
+          </div>
+          <p>{task.result || task.summary || '任务还没有给出最终结果。'}</p>
+        </article>
+
+        <article className="task-detail-panel task-detail-panel-wide task-detail-panel-muted">
+          <div className="task-detail-panel-head">
+            <TimerReset size={16} />
+            <strong>当前状态说明</strong>
+          </div>
+          <p>
+            {task.state === 'completed'
+              ? '这条任务已经结束，后续如果继续补充要求，会新建一条 continuation task，并保留当前任务记录。'
+              : task.state === 'running'
+                ? '任务正在后台推进中。你可以继续正常聊天，也可以直接追问这条任务的当前进展。'
+                : task.state === 'accepted'
+                  ? '任务已经被系统接收，正在等待调度执行。'
+                  : task.state === 'failed'
+                    ? '任务已失败，建议查看右侧事件流和 Claude 记录定位问题。'
+                    : '任务已取消，当前不会继续推进。'}
+          </p>
+        </article>
+      </div>
     </SectionCard>
   )
 }

--- a/web/src/components/dashboard/TaskListPane.tsx
+++ b/web/src/components/dashboard/TaskListPane.tsx
@@ -1,0 +1,70 @@
+import { Clock3, FolderHeart, Sparkles } from 'lucide-react'
+import { formatTime } from '../../lib/dashboard'
+import type { Task } from '../../types'
+import { EmptyState } from '../ui/EmptyState'
+import { SectionCard } from '../ui/SectionCard'
+import { StatusBadge } from '../ui/StatusBadge'
+
+type Props = {
+  tasks: Task[]
+  selectedTaskID: string | null
+  onSelect: (taskID: string) => void
+}
+
+export function TaskListPane({ tasks, selectedTaskID, onSelect }: Props) {
+  return (
+    <SectionCard
+      className="dashboard-rail-card"
+      description="把复杂任务交给小爱之后，这里会像任务收纳盒一样把每一条进展都排好。"
+      eyebrow="TASK POCKET"
+      title="任务队列"
+    >
+      {tasks.length === 0 ? (
+        <EmptyState
+          title="暂时还没有任务"
+          description="先让小爱接一个网页、整理、写作或资料任务，这里就会热闹起来。"
+        />
+      ) : (
+        <div className="task-list-stack">
+          {tasks.map((task) => {
+            const selected = task.id === selectedTaskID
+            return (
+              <button
+                key={task.id}
+                className={`task-teaser ${selected ? 'task-teaser-active' : ''}`}
+                onClick={() => onSelect(task.id)}
+                type="button"
+              >
+                <div className="task-teaser-head">
+                  <StatusBadge state={task.state} />
+                  {task.report_pending ? (
+                    <span className="soft-chip">
+                      <Sparkles size={14} />
+                      待补报
+                    </span>
+                  ) : null}
+                </div>
+
+                <div className="task-teaser-copy">
+                  <strong>{task.title}</strong>
+                  <p>{task.summary || task.input || '这条任务还没有阶段摘要。'}</p>
+                </div>
+
+                <div className="task-teaser-meta">
+                  <span>
+                    <Clock3 size={14} />
+                    {formatTime(task.updated_at)}
+                  </span>
+                  <span>
+                    <FolderHeart size={14} />
+                    {task.kind}
+                  </span>
+                </div>
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </SectionCard>
+  )
+}

--- a/web/src/components/dashboard/TaskListPane.tsx
+++ b/web/src/components/dashboard/TaskListPane.tsx
@@ -1,4 +1,5 @@
-import { Clock3, FolderHeart, Sparkles } from 'lucide-react'
+import { Clock3, Funnel, Sparkles } from 'lucide-react'
+import { countByState } from '../../lib/dashboard'
 import { formatTime } from '../../lib/dashboard'
 import type { Task } from '../../types'
 import { EmptyState } from '../ui/EmptyState'
@@ -12,12 +13,25 @@ type Props = {
 }
 
 export function TaskListPane({ tasks, selectedTaskID, onSelect }: Props) {
+  const summary = [
+    { label: '全部', value: tasks.length, tone: 'neutral' },
+    { label: '运行中', value: countByState(tasks, 'running'), tone: 'running' },
+    { label: '已完成', value: countByState(tasks, 'completed'), tone: 'completed' },
+    { label: '失败', value: countByState(tasks, 'failed'), tone: 'failed' },
+    { label: '已取消', value: countByState(tasks, 'canceled'), tone: 'canceled' },
+  ]
+
   return (
     <SectionCard
+      actions={(
+        <span className="card-inline-icon">
+          <Funnel size={16} />
+        </span>
+      )}
       className="dashboard-rail-card"
-      description="把复杂任务交给小爱之后，这里会像任务收纳盒一样把每一条进展都排好。"
-      eyebrow="TASK POCKET"
-      title="任务队列"
+      description="按最近更新时间排序，方便快速切到当前最需要盯住的那条任务。"
+      eyebrow="TASK CENTER"
+      title="任务列表"
     >
       {tasks.length === 0 ? (
         <EmptyState
@@ -25,7 +39,17 @@ export function TaskListPane({ tasks, selectedTaskID, onSelect }: Props) {
           description="先让小爱接一个网页、整理、写作或资料任务，这里就会热闹起来。"
         />
       ) : (
-        <div className="task-list-stack">
+        <div className="task-list-shell">
+          <div className="task-list-summary-grid">
+            {summary.map((item) => (
+              <article className={`task-list-summary-card task-list-summary-${item.tone}`} key={item.label}>
+                <strong>{item.value}</strong>
+                <span>{item.label}</span>
+              </article>
+            ))}
+          </div>
+
+          <div className="task-list-stack">
           {tasks.map((task) => {
             const selected = task.id === selectedTaskID
             return (
@@ -36,33 +60,36 @@ export function TaskListPane({ tasks, selectedTaskID, onSelect }: Props) {
                 type="button"
               >
                 <div className="task-teaser-head">
-                  <StatusBadge state={task.state} />
-                  {task.report_pending ? (
-                    <span className="soft-chip">
-                      <Sparkles size={14} />
-                      待补报
-                    </span>
-                  ) : null}
+                  <div className="task-teaser-copy">
+                    <strong>{task.title}</strong>
+                    <p>{formatTime(task.updated_at)}</p>
+                  </div>
+                  <div className="task-teaser-side">
+                    <StatusBadge state={task.state} />
+                    {task.report_pending ? (
+                      <span className="soft-chip">
+                        <Sparkles size={14} />
+                        待补报
+                      </span>
+                    ) : null}
+                  </div>
                 </div>
 
-                <div className="task-teaser-copy">
-                  <strong>{task.title}</strong>
-                  <p>{task.summary || task.input || '这条任务还没有阶段摘要。'}</p>
-                </div>
+                <p className="task-teaser-summary">{task.summary || task.input || '这条任务还没有阶段摘要。'}</p>
 
                 <div className="task-teaser-meta">
                   <span>
                     <Clock3 size={14} />
-                    {formatTime(task.updated_at)}
+                    {formatTime(task.created_at)}
                   </span>
                   <span>
-                    <FolderHeart size={14} />
                     {task.kind}
                   </span>
                 </div>
               </button>
             )
           })}
+          </div>
         </div>
       )}
     </SectionCard>

--- a/web/src/components/dashboard/TaskSideCards.tsx
+++ b/web/src/components/dashboard/TaskSideCards.tsx
@@ -1,0 +1,185 @@
+import { Bot, Download, FileBox, MessageCircleMore, ScrollText } from 'lucide-react'
+import { formatBytes, formatTime } from '../../lib/dashboard'
+import type { ClaudeRecord, TaskArtifact, TaskEvent } from '../../types'
+import { EmptyState } from '../ui/EmptyState'
+import { SectionCard } from '../ui/SectionCard'
+import { StatusBadge } from '../ui/StatusBadge'
+
+export function TaskEventsCard({ events }: { events: TaskEvent[] }) {
+  return (
+    <SectionCard
+      className="dashboard-side-card"
+      actions={<span className="section-link">查看全部</span>}
+      eyebrow="TIMELINE"
+      title="任务事件流"
+    >
+      {events.length === 0 ? (
+        <EmptyState title="还没有事件" description="等任务开始推进，这里会按时间顺序记录每一步动作。" />
+      ) : (
+        <div className="timeline-list">
+          {events.slice(0, 6).map((event, index) => (
+            <article className="timeline-row" key={event.id}>
+              <div className={`timeline-dot timeline-dot-${index % 5}`} />
+              <span className="timeline-time">{formatTime(event.created_at)}</span>
+              <strong>{event.type}</strong>
+              <p>{event.message}</p>
+            </article>
+          ))}
+        </div>
+      )}
+    </SectionCard>
+  )
+}
+
+export function TaskArtifactsCard({ artifacts }: { artifacts: TaskArtifact[] }) {
+  return (
+    <SectionCard
+      className="dashboard-side-card"
+      actions={<span className="section-link">查看全部</span>}
+      eyebrow="FILES"
+      title="Artifacts"
+    >
+      {artifacts.length === 0 ? (
+        <EmptyState title="还没有产物" description="当任务输出文件、网页、图片或文档时，会出现在这里。" />
+      ) : (
+        <div className="artifact-table">
+          <div className="artifact-table-head">
+            <span>文件名</span>
+            <span>类型</span>
+            <span>大小</span>
+            <span>操作</span>
+          </div>
+          {artifacts.slice(0, 4).map((artifact) => (
+            <div className="artifact-table-row" key={artifact.id}>
+              <div className="artifact-file-cell">
+                <FileBox size={15} />
+                <span>{artifact.file_name}</span>
+              </div>
+              <span>{artifact.kind}</span>
+              <span>{formatBytes(artifact.size_bytes)}</span>
+              <a
+                className="artifact-download-button"
+                href={`/api/tasks/${encodeURIComponent(artifact.task_id)}/artifacts/${encodeURIComponent(artifact.id)}/download`}
+              >
+                <Download size={14} />
+              </a>
+            </div>
+          ))}
+        </div>
+      )}
+    </SectionCard>
+  )
+}
+
+export function ClaudeRecordCard({ claudeRecord }: { claudeRecord: ClaudeRecord | null }) {
+  return (
+    <SectionCard className="dashboard-side-card" eyebrow="EXECUTOR" title="Claude 记录">
+      {!claudeRecord ? (
+        <EmptyState title="没有 Claude 记录" description="如果当前任务走的是 Claude Code，这里会展示会话和最近状态。" />
+      ) : (
+        <div className="record-facts">
+          <div className="record-facts-row">
+            <span>执行器</span>
+            <strong>Claude Code</strong>
+          </div>
+          <div className="record-facts-row">
+            <span>会话状态</span>
+            <StatusBadge state={claudeRecord.status} />
+          </div>
+          <div className="record-facts-row">
+            <span>Claude 会话</span>
+            <code>{claudeRecord.session_id || '未建立'}</code>
+          </div>
+          <div className="record-facts-row record-facts-row-top">
+            <span>最近动作</span>
+            <p>{claudeRecord.last_summary || claudeRecord.last_assistant_text || '暂无可展示的执行摘要。'}</p>
+          </div>
+          <div className="record-facts-row">
+            <span>工作目录</span>
+            <code>{claudeRecord.working_directory || '—'}</code>
+          </div>
+        </div>
+      )}
+    </SectionCard>
+  )
+}
+
+export function RecentConversationCard({
+  lastActive,
+  messages,
+}: {
+  lastActive: string
+  messages: Array<{ role: string; content: string }>
+}) {
+  const items = messages.slice(-3)
+
+  return (
+    <SectionCard
+      className="dashboard-side-card"
+      actions={<span className="section-link">查看全部</span>}
+      eyebrow="MEMORY"
+      title="最近会话"
+    >
+      {items.length === 0 ? (
+        <EmptyState title="还没有会话" description="等你和小爱多说几句，这里就会开始保留最近上下文。" />
+      ) : (
+        <div className="recent-conversation-list">
+          {items.map((message, index) => (
+            <article className="recent-conversation-row" key={`${message.role}-${index}`}>
+              <span className={`recent-conversation-avatar recent-conversation-avatar-${message.role === 'user' ? 'user' : 'assistant'}`}>
+                {message.role === 'user' ? '你' : '助'}
+              </span>
+              <div className="recent-conversation-copy">
+                <strong>{message.role === 'user' ? '用户' : '助手'}</strong>
+                <p>{message.content}</p>
+              </div>
+              <span className="recent-conversation-time">{formatTime(lastActive)}</span>
+            </article>
+          ))}
+        </div>
+      )}
+    </SectionCard>
+  )
+}
+
+export function EmptyClaudeCard() {
+  return (
+    <SectionCard className="dashboard-side-card" eyebrow="EXECUTOR" title="Claude 记录">
+      <div className="empty-inline-card">
+        <Bot size={18} />
+        <div>
+          <strong>当前任务没有执行器记录</strong>
+          <p>如果它是通过 Claude Code 跑起来的，这里会补上会话与最近动作。</p>
+        </div>
+      </div>
+    </SectionCard>
+  )
+}
+
+export function EmptyConversationCard() {
+  return (
+    <SectionCard className="dashboard-side-card" eyebrow="MEMORY" title="最近会话">
+      <div className="empty-inline-card">
+        <MessageCircleMore size={18} />
+        <div>
+          <strong>还没有会话片段</strong>
+          <p>和小爱先说上几句，这里就会开始保留最近对话。</p>
+        </div>
+      </div>
+    </SectionCard>
+  )
+}
+
+export function EmptyTimelineCard() {
+  return (
+    <SectionCard className="dashboard-side-card" eyebrow="TIMELINE" title="任务事件流">
+      <div className="empty-inline-card">
+        <ScrollText size={18} />
+        <div>
+          <strong>还没有任务事件</strong>
+          <p>一旦任务开始推进，这里就会按顺序展示受理、执行、产物写入等事件。</p>
+        </div>
+      </div>
+    </SectionCard>
+  )
+}

--- a/web/src/components/settings/IMDebugSendPanel.tsx
+++ b/web/src/components/settings/IMDebugSendPanel.tsx
@@ -66,13 +66,13 @@ export function IMDebugSendPanel({
       <div className="panel-head compact">
         <div>
           <p className="eyebrow">IM DEBUG</p>
-          <h3>默认渠道调试</h3>
+          <h3>手动调试发送</h3>
         </div>
       </div>
 
       <div className="settings-form">
         <p className="settings-note">
-          这里始终命中当前已经保存的默认渠道，不依赖自动镜像开关。适合单独验证账号、目标和通道是否正常。
+          这里始终命中当前已经保存的默认渠道，不依赖自动镜像开关。适合单独确认这条触达到底通不通。
         </p>
 
         {ready ? (
@@ -96,7 +96,7 @@ export function IMDebugSendPanel({
 
         {configDirty ? (
           <div className="settings-feedback">
-            上方镜像配置还有未保存的修改；调试发送仍然会命中当前已保存的默认渠道。
+            上方还有未保存的修改；这里仍然会命中“已经保存”的默认渠道。
           </div>
         ) : null}
 
@@ -138,7 +138,7 @@ export function IMDebugSendPanel({
             onChange={(event) => onImageFileChange(event.target.files?.[0] ?? null)}
           />
           <span className="settings-note">
-            {imageFileName ? `已选择：${imageFileName}` : '只接受图片文件，服务端会先落到媒体缓存目录，再按微信协议发送。'}
+            {imageFileName ? `已选择：${imageFileName}` : '只接受图片文件。'}
           </span>
         </label>
 
@@ -179,7 +179,7 @@ export function IMDebugSendPanel({
             onChange={(event) => onFileFileChange(event.target.files?.[0] ?? null)}
           />
           <span className="settings-note">
-            {fileFileName ? `已选择：${fileFileName}` : '允许选择任意文件，服务端会先落到媒体缓存目录，再按微信文件消息发送。'}
+            {fileFileName ? `已选择：${fileFileName}` : '可以发送任意文件。'}
           </span>
         </label>
 

--- a/web/src/components/settings/IMDeliveryPanel.tsx
+++ b/web/src/components/settings/IMDeliveryPanel.tsx
@@ -39,7 +39,7 @@ export function IMDeliveryPanel({
       <div className="panel-head compact">
         <div>
           <p className="eyebrow">IM DELIVERY</p>
-          <h3>回复镜像到微信</h3>
+          <h3>默认触达</h3>
         </div>
       </div>
 
@@ -50,7 +50,7 @@ export function IMDeliveryPanel({
             onChange={(event) => onEnabledChange(event.target.checked)}
             type="checkbox"
           />
-          <span>开启后，小爱的正常回复会异步再发一份到微信。</span>
+          <span>开启后，小爱的正常回复会悄悄再发一份到默认微信对象。</span>
         </label>
 
         <label className="settings-field">
@@ -86,7 +86,7 @@ export function IMDeliveryPanel({
               </option>
             ))}
           </select>
-          <span className="settings-note">镜像投递只能选择已经在下方“触达目标管理”里配置好的对象。</span>
+          <span className="settings-note">这里只能从已经配置好的对象里选，避免把消息发到未知目标。</span>
         </label>
 
         <div className="settings-actions">
@@ -98,7 +98,7 @@ export function IMDeliveryPanel({
           >
             {saving ? '保存中...' : '保存镜像设置'}
           </button>
-          <span className="settings-note">发送为异步副作用，不阻塞小爱当前播报。</span>
+          <span className="settings-note">这条转发不会打断小爱当前的播报节奏。</span>
         </div>
 
         {feedback ? <div className="settings-feedback">{feedback}</div> : null}

--- a/web/src/components/settings/IMTargetsPanel.tsx
+++ b/web/src/components/settings/IMTargetsPanel.tsx
@@ -42,7 +42,7 @@ export function IMTargetsPanel({
       <div className="panel-head compact">
         <div>
           <p className="eyebrow">TARGETS</p>
-          <h3>触达目标管理</h3>
+          <h3>触达对象</h3>
         </div>
       </div>
 
@@ -100,7 +100,7 @@ export function IMTargetsPanel({
             >
               {saving ? '保存中...' : '保存目标'}
             </button>
-            <span className="settings-note">如果扫码返回了用户 ID，系统通常会自动补一个“扫码用户”目标。</span>
+            <span className="settings-note">如果扫码阶段拿到了用户 ID，系统通常会自动补一个“扫码用户”对象。</span>
           </div>
 
           {feedback ? <div className="settings-feedback">{feedback}</div> : null}
@@ -134,4 +134,3 @@ export function IMTargetsPanel({
     </article>
   )
 }
-

--- a/web/src/components/settings/SessionSettingsPanel.tsx
+++ b/web/src/components/settings/SessionSettingsPanel.tsx
@@ -50,7 +50,7 @@ export function SessionSettingsPanel({
           >
             {settingsSaving ? '保存中...' : '保存设置'}
           </button>
-          <span className="settings-note">默认值 300 秒，只保留滑动窗口策略。</span>
+          <span className="settings-note">默认是 300 秒，越长越像延续聊天，越短越像重新开场。</span>
         </div>
 
         {settingsFeedback ? <div className="settings-feedback">{settingsFeedback}</div> : null}
@@ -59,4 +59,3 @@ export function SessionSettingsPanel({
     </article>
   )
 }
-

--- a/web/src/components/settings/WeChatAccountsPanel.tsx
+++ b/web/src/components/settings/WeChatAccountsPanel.tsx
@@ -14,7 +14,7 @@ export function WeChatAccountsPanel({ accounts, loginBusy, onStartLogin, onDelet
       <div className="panel-head compact">
         <div>
           <p className="eyebrow">WECHAT ACCOUNTS</p>
-          <h3>账号管理</h3>
+          <h3>微信账号</h3>
         </div>
         <button className="settings-button" disabled={loginBusy} onClick={() => onStartLogin()} type="button">
           {loginBusy ? '登录流程进行中...' : '新增微信账号'}

--- a/web/src/components/settings/WeChatLoginPanel.tsx
+++ b/web/src/components/settings/WeChatLoginPanel.tsx
@@ -52,7 +52,7 @@ export function WeChatLoginPanel({
         {confirmed ? (
           <div className="settings-login-confirm">
             <p className="settings-note">
-              扫码授权已经完成。确认后，这个微信账号才会加入当前网关账号列表，并自动补一个“扫码用户”默认触达目标。
+              扫码已经完成。只有你确认之后，这个账号才会真正加入系统，并自动补上一个“扫码用户”默认触达对象。
             </p>
 
             {message ? <div className="settings-feedback">{message}</div> : null}
@@ -96,7 +96,7 @@ export function WeChatLoginPanel({
 
             <div className="login-copy">
               <p className="settings-note">
-                当前阶段只做微信文本触达，不做 IM 入站会话。扫码确认后，界面会先展示待添加的账号信息，只有你点确认才会真正保存登录态。
+                扫码确认后，界面会先展示待添加的账号信息。只有你点确认，登录态才会真正保存下来。
               </p>
               {message ? <div className="settings-feedback">{message}</div> : null}
               {error ? <div className="error-banner settings-error">{error}</div> : null}
@@ -115,7 +115,7 @@ export function WeChatLoginPanel({
 
               <div className="settings-actions">
                 <span className="settings-note">
-                  {loading ? '正在拉起微信登录流程。' : polling ? '等待扫码与确认，不会直接把账号写入系统。' : '关闭弹窗后可重新发起一次扫码。'}
+                  {loading ? '正在准备扫码流程。' : polling ? '正在等待扫码与确认，不会自动把账号写进系统。' : '关闭弹窗后可以重新发起一次扫码。'}
                 </span>
               </div>
             </div>

--- a/web/src/components/ui/EmptyState.tsx
+++ b/web/src/components/ui/EmptyState.tsx
@@ -1,0 +1,13 @@
+type Props = {
+  title: string
+  description: string
+}
+
+export function EmptyState({ title, description }: Props) {
+  return (
+    <div className="empty-state">
+      <strong>{title}</strong>
+      <p>{description}</p>
+    </div>
+  )
+}

--- a/web/src/components/ui/PillTabs.tsx
+++ b/web/src/components/ui/PillTabs.tsx
@@ -8,11 +8,12 @@ type Props<T extends string> = {
   tabs: Tab<T>[]
   value: T
   onChange: (value: T) => void
+  className?: string
 }
 
-export function PillTabs<T extends string>({ tabs, value, onChange }: Props<T>) {
+export function PillTabs<T extends string>({ tabs, value, onChange, className }: Props<T>) {
   return (
-    <div className="pill-tabs" role="tablist">
+    <div className={className ? `pill-tabs ${className}` : 'pill-tabs'} role="tablist">
       {tabs.map((tab) => {
         const active = tab.key === value
         return (

--- a/web/src/components/ui/PillTabs.tsx
+++ b/web/src/components/ui/PillTabs.tsx
@@ -1,0 +1,34 @@
+type Tab<T extends string> = {
+  key: T
+  label: string
+  caption?: string
+}
+
+type Props<T extends string> = {
+  tabs: Tab<T>[]
+  value: T
+  onChange: (value: T) => void
+}
+
+export function PillTabs<T extends string>({ tabs, value, onChange }: Props<T>) {
+  return (
+    <div className="pill-tabs" role="tablist">
+      {tabs.map((tab) => {
+        const active = tab.key === value
+        return (
+          <button
+            key={tab.key}
+            aria-selected={active}
+            className={`pill-tab ${active ? 'pill-tab-active' : ''}`}
+            onClick={() => onChange(tab.key)}
+            role="tab"
+            type="button"
+          >
+            <strong>{tab.label}</strong>
+            {tab.caption ? <span>{tab.caption}</span> : null}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/web/src/components/ui/SectionCard.tsx
+++ b/web/src/components/ui/SectionCard.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react'
+
+type Props = {
+  eyebrow?: string
+  title?: string
+  description?: string
+  actions?: ReactNode
+  children?: ReactNode
+  className?: string
+}
+
+export function SectionCard({ eyebrow, title, description, actions, children, className }: Props) {
+  return (
+    <section className={`section-card ${className ?? ''}`.trim()}>
+      {(eyebrow || title || description || actions) ? (
+        <header className="section-card-head">
+          <div className="section-card-copy">
+            {eyebrow ? <p className="section-eyebrow">{eyebrow}</p> : null}
+            {title ? <h3 className="section-title">{title}</h3> : null}
+            {description ? <p className="section-description">{description}</p> : null}
+          </div>
+          {actions ? <div className="section-card-actions">{actions}</div> : null}
+        </header>
+      ) : null}
+
+      {children ? <div className="section-card-body">{children}</div> : null}
+    </section>
+  )
+}

--- a/web/src/components/ui/StatusBadge.tsx
+++ b/web/src/components/ui/StatusBadge.tsx
@@ -1,0 +1,10 @@
+import type { TaskState } from '../../types'
+import { stateLabels } from '../../lib/dashboard'
+
+type Props = {
+  state: TaskState
+}
+
+export function StatusBadge({ state }: Props) {
+  return <span className={`status-badge status-${state}`}>{stateLabels[state]}</span>
+}

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -1,10 +1,15 @@
-import { BellDot, FolderKanban, MessageCircleMore, Send } from 'lucide-react'
+import { Ban, CircleCheckBig, CircleOff, FolderKanban, PlayCircle, RefreshCw } from 'lucide-react'
 import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react'
-import { countByState, latest } from '../lib/dashboard'
+import { countByState, formatTime, latest } from '../lib/dashboard'
 import type { ClaudeRecord, ConversationSnapshot, DashboardState, TaskEvent } from '../types'
-import { ConversationPane } from '../components/dashboard/ConversationPane'
-import { TaskDetailPane, type TaskDetailTab } from '../components/dashboard/TaskDetailPane'
+import { TaskDetailPane } from '../components/dashboard/TaskDetailPane'
 import { TaskListPane } from '../components/dashboard/TaskListPane'
+import {
+  ClaudeRecordCard,
+  RecentConversationCard,
+  TaskArtifactsCard,
+  TaskEventsCard,
+} from '../components/dashboard/TaskSideCards'
 
 type Props = {
   data: DashboardState
@@ -15,7 +20,7 @@ type Props = {
 
 export function DashboardPage({ data, loading, error, setData: _setData }: Props) {
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null)
-  const [detailTab, setDetailTab] = useState<TaskDetailTab>('overview')
+  const [lastRefreshedAt, setLastRefreshedAt] = useState(() => new Date())
 
   useEffect(() => {
     if (data.tasks.length === 0) {
@@ -27,6 +32,11 @@ export function DashboardPage({ data, loading, error, setData: _setData }: Props
     }
     setSelectedTaskId(data.tasks[0].id)
   }, [data.tasks, selectedTaskId])
+
+  useEffect(() => {
+    if (loading) return
+    setLastRefreshedAt(new Date())
+  }, [data, loading])
 
   const heroTask = latest(data.tasks)
   const selectedTask = data.tasks.find((task) => task.id === selectedTaskId) ?? heroTask ?? null
@@ -59,86 +69,79 @@ export function DashboardPage({ data, loading, error, setData: _setData }: Props
     return data.conversations[0] ?? null
   }, [data.conversations])
 
-  const overviewCards = useMemo(() => {
+  const stats = useMemo(() => {
     return [
-      {
-        label: '排队中的事情',
-        value: data.tasks.length,
-        note: '今天小爱接到的任务',
-        Icon: FolderKanban,
-        tone: 'peach',
-      },
-      {
-        label: '正在处理',
-        value: countByState(data.tasks, 'running'),
-        note: '后台持续推进',
-        Icon: Send,
-        tone: 'mint',
-      },
-      {
-        label: '待补报',
-        value: data.tasks.filter((task) => task.report_pending).length,
-        note: '下次聊天会顺带告诉你',
-        Icon: BellDot,
-        tone: 'sky',
-      },
-      {
-        label: '最近会话',
-        value: activeConversation?.messages.length ?? 0,
-        note: '上下文还在记着',
-        Icon: MessageCircleMore,
-        tone: 'butter',
-      },
+      { label: '任务总数', value: data.tasks.length, Icon: FolderKanban, tone: 'neutral' },
+      { label: '运行中', value: countByState(data.tasks, 'running'), Icon: PlayCircle, tone: 'running' },
+      { label: '已完成', value: countByState(data.tasks, 'completed'), Icon: CircleCheckBig, tone: 'completed' },
+      { label: '失败', value: countByState(data.tasks, 'failed'), Icon: CircleOff, tone: 'failed' },
+      { label: '已取消', value: countByState(data.tasks, 'canceled'), Icon: Ban, tone: 'canceled' },
     ]
-  }, [activeConversation?.messages.length, data.tasks])
+  }, [data.tasks])
 
   return (
-    <main className="page-shell dashboard-shell">
-      <header className="page-hero">
-        <div className="page-hero-copy">
-          <p className="section-eyebrow">TODAY WITH XIAOAI</p>
-          <h2>{selectedTask ? `这会儿正围着「${selectedTask.title}」忙活` : '先和小爱说一句话，让今天开始转起来'}</h2>
-          <p>
-            这里不再混入系统设置和技术说明。你只会看到现在最有用的三类信息：任务进展、交付文件、最近对话。
-          </p>
+    <main className="page-shell dashboard-shell dashboard-page">
+      <header className="dashboard-header">
+        <div className="dashboard-header-title">
+          <div className="dashboard-title-row">
+            <h2>Dashboard 首页</h2>
+            <span className={`service-pill ${error ? 'service-pill-danger' : ''}`}>{error ? '服务异常' : '服务正常'}</span>
+          </div>
+          <p>把任务、执行过程、交付文件和最近会话放回一个稳定、清爽、可追踪的工作台里。</p>
         </div>
 
-        <div className="hero-metrics">
-          {overviewCards.map(({ Icon, label, note, tone, value }) => (
-            <article className={`hero-metric hero-metric-${tone}`} key={label}>
+        <div className="dashboard-header-stats">
+          {stats.map(({ Icon, label, tone, value }) => (
+            <article className={`dashboard-stat-card dashboard-stat-card-${tone}`} key={label}>
               <span>
-                <Icon size={16} />
+                <Icon size={18} />
                 {label}
               </span>
               <strong>{value}</strong>
-              <small>{note}</small>
             </article>
           ))}
+
+          <article className="dashboard-stat-card dashboard-stat-card-refresh">
+            <span>
+              <RefreshCw size={18} />
+              刷新
+            </span>
+            <strong>{loading ? '同步中' : '已同步'}</strong>
+            <small>最近更新: {formatTime(lastRefreshedAt.toISOString())}</small>
+          </article>
         </div>
       </header>
 
-      {error ? <div className="banner-error">接口暂时有点卡住了：{error}</div> : null}
-      {loading ? <div className="banner-hint">正在更新最新状态…</div> : null}
+      {error ? <div className="banner-error">接口当前不可用：{error}</div> : null}
 
-      <section className="dashboard-layout">
-        <div className="dashboard-rail">
-          <TaskListPane tasks={data.tasks} selectedTaskID={selectedTask?.id ?? null} onSelect={(taskID) => {
-            setSelectedTaskId(taskID)
-            setDetailTab('overview')
-          }} />
+      <section className="dashboard-reference-grid">
+        <div className="dashboard-left-column">
+          <TaskListPane
+            tasks={data.tasks}
+            selectedTaskID={selectedTask?.id ?? null}
+            onSelect={(taskID) => {
+              setSelectedTaskId(taskID)
+            }}
+          />
         </div>
 
-        <div className="dashboard-stage">
+        <div className="dashboard-center-column">
           <TaskDetailPane
             artifacts={selectedArtifacts}
             claudeRecord={claudeRecord}
             events={selectedEvents}
-            onTabChange={setDetailTab}
-            tab={detailTab}
             task={selectedTask}
           />
+        </div>
 
-          <ConversationPane conversation={activeConversation} />
+        <div className="dashboard-right-column">
+          <TaskEventsCard events={selectedEvents} />
+          <TaskArtifactsCard artifacts={selectedArtifacts} />
+          <ClaudeRecordCard claudeRecord={claudeRecord} />
+          <RecentConversationCard
+            lastActive={activeConversation?.last_active ?? ''}
+            messages={activeConversation?.messages ?? []}
+          />
         </div>
       </section>
     </main>

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -1,13 +1,10 @@
+import { BellDot, FolderKanban, MessageCircleMore, Send } from 'lucide-react'
 import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react'
-import { postJSON } from '../lib/api'
-import { countByState, formatBytes, formatTime, latest, normalizeSettings, stateLabels } from '../lib/dashboard'
-import type {
-  ClaudeRecord,
-  ConversationSnapshot,
-  DashboardState,
-  SessionSettings,
-  TaskEvent,
-} from '../types'
+import { countByState, latest } from '../lib/dashboard'
+import type { ClaudeRecord, ConversationSnapshot, DashboardState, TaskEvent } from '../types'
+import { ConversationPane } from '../components/dashboard/ConversationPane'
+import { TaskDetailPane, type TaskDetailTab } from '../components/dashboard/TaskDetailPane'
+import { TaskListPane } from '../components/dashboard/TaskListPane'
 
 type Props = {
   data: DashboardState
@@ -16,18 +13,9 @@ type Props = {
   setData: Dispatch<SetStateAction<DashboardState>>
 }
 
-export function DashboardPage({ data, loading, error, setData }: Props) {
+export function DashboardPage({ data, loading, error, setData: _setData }: Props) {
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null)
-  const [windowInput, setWindowInput] = useState('300')
-  const [windowDirty, setWindowDirty] = useState(false)
-  const [settingsSaving, setSettingsSaving] = useState(false)
-  const [settingsFeedback, setSettingsFeedback] = useState<string | null>(null)
-  const [settingsError, setSettingsError] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (windowDirty || settingsSaving) return
-    setWindowInput(String(data.settings.session_window_seconds))
-  }, [data.settings.session_window_seconds, settingsSaving, windowDirty])
+  const [detailTab, setDetailTab] = useState<TaskDetailTab>('overview')
 
   useEffect(() => {
     if (data.tasks.length === 0) {
@@ -40,22 +28,9 @@ export function DashboardPage({ data, loading, error, setData }: Props) {
     setSelectedTaskId(data.tasks[0].id)
   }, [data.tasks, selectedTaskId])
 
-  const metrics = useMemo(() => {
-    const completed = countByState(data.tasks, 'completed')
-    const running = countByState(data.tasks, 'running')
-    const failed = countByState(data.tasks, 'failed')
-    const pendingReports = data.tasks.filter((task) => task.report_pending).length
-
-    return [
-      { label: '总任务', value: data.tasks.length, accent: 'cyan' },
-      { label: '执行中', value: running, accent: 'amber' },
-      { label: '已完成', value: completed, accent: 'mint' },
-      { label: '待补报', value: pendingReports, accent: 'rose' },
-      { label: '失败数', value: failed, accent: 'violet' },
-    ]
-  }, [data.tasks])
-
   const heroTask = latest(data.tasks)
+  const selectedTask = data.tasks.find((task) => task.id === selectedTaskId) ?? heroTask ?? null
+
   const eventsByTask = useMemo(() => {
     const grouped = new Map<string, TaskEvent[]>()
     for (const event of data.events) {
@@ -69,382 +44,103 @@ export function DashboardPage({ data, loading, error, setData }: Props) {
     return grouped
   }, [data.events])
 
-  const selectedTask =
-    data.tasks.find((task) => task.id === selectedTaskId) ?? heroTask ?? null
   const selectedEvents = selectedTask ? eventsByTask.get(selectedTask.id) ?? [] : []
   const selectedArtifacts = useMemo(() => {
     if (!selectedTask) return []
     return data.artifacts.filter((artifact) => artifact.task_id === selectedTask.id)
   }, [data.artifacts, selectedTask])
+
   const claudeRecord = useMemo<ClaudeRecord | null>(() => {
     if (!selectedTask) return null
     return data.claude_records.find((record) => record.task_id === selectedTask.id) ?? null
   }, [data.claude_records, selectedTask])
+
   const activeConversation = useMemo<ConversationSnapshot | null>(() => {
     return data.conversations[0] ?? null
   }, [data.conversations])
-  const activeConversationMessages = activeConversation?.messages ?? []
 
-  async function saveSessionWindowSettings() {
-    const nextValue = Number(windowInput)
-    if (!Number.isInteger(nextValue)) {
-      setSettingsError('请输入整数秒数。')
-      setSettingsFeedback(null)
-      return
-    }
-
-    setSettingsSaving(true)
-    setSettingsError(null)
-    setSettingsFeedback(null)
-
-    try {
-      const payload = await postJSON<{ session?: SessionSettings }>('/api/settings/session', {
-        window_seconds: nextValue,
-      })
-      const nextSettings = normalizeSettings(payload.session)
-      setData((current) => ({
-        ...current,
-        settings: {
-          ...current.settings,
-          ...nextSettings,
-        },
-      }))
-      setWindowInput(String(nextSettings.session_window_seconds))
-      setWindowDirty(false)
-      setSettingsFeedback('已保存，后续请求会立即按新的滑动窗口秒数生效。')
-    } catch (err) {
-      setSettingsError(err instanceof Error ? err.message : '保存失败')
-    } finally {
-      setSettingsSaving(false)
-    }
-  }
+  const overviewCards = useMemo(() => {
+    return [
+      {
+        label: '排队中的事情',
+        value: data.tasks.length,
+        note: '今天小爱接到的任务',
+        Icon: FolderKanban,
+        tone: 'peach',
+      },
+      {
+        label: '正在处理',
+        value: countByState(data.tasks, 'running'),
+        note: '后台持续推进',
+        Icon: Send,
+        tone: 'mint',
+      },
+      {
+        label: '待补报',
+        value: data.tasks.filter((task) => task.report_pending).length,
+        note: '下次聊天会顺带告诉你',
+        Icon: BellDot,
+        tone: 'sky',
+      },
+      {
+        label: '最近会话',
+        value: activeConversation?.messages.length ?? 0,
+        note: '上下文还在记着',
+        Icon: MessageCircleMore,
+        tone: 'butter',
+      },
+    ]
+  }, [activeConversation?.messages.length, data.tasks])
 
   return (
-    <>
-      <header className="hero">
-        <div className="hero-copy">
-          <p className="eyebrow">LINGXI / TASK CONTROL</p>
-          <h2>异步任务看板</h2>
-          <p className="hero-text">
-            React 前端只负责看板和状态感知。Go 侧退回纯 API 服务，任务状态、事件流和补报都通过
-            <code>/api/state</code> 提供。
+    <main className="page-shell dashboard-shell">
+      <header className="page-hero">
+        <div className="page-hero-copy">
+          <p className="section-eyebrow">TODAY WITH XIAOAI</p>
+          <h2>{selectedTask ? `这会儿正围着「${selectedTask.title}」忙活` : '先和小爱说一句话，让今天开始转起来'}</h2>
+          <p>
+            这里不再混入系统设置和技术说明。你只会看到现在最有用的三类信息：任务进展、交付文件、最近对话。
           </p>
         </div>
 
-        <section className="hero-panel hero-panel-conversation">
-          <div className="hero-panel-head">
-            <div>
-              <div className="hero-panel-label">CURRENT CONTEXT</div>
-              <h3>会话历史</h3>
-            </div>
-            {activeConversation ? (
-              <span className="panel-meta">
-                {activeConversationMessages.length} 条消息 · 最近活跃 {formatTime(activeConversation.last_active)}
+        <div className="hero-metrics">
+          {overviewCards.map(({ Icon, label, note, tone, value }) => (
+            <article className={`hero-metric hero-metric-${tone}`} key={label}>
+              <span>
+                <Icon size={16} />
+                {label}
               </span>
-            ) : null}
-          </div>
-          {activeConversation ? (
-            <div className="conversation-list conversation-list-hero">
-              {activeConversationMessages.map((message, index) => (
-                <article
-                  className={`conversation-bubble conversation-${message.role}`}
-                  key={`${activeConversation.id}-${index}`}
-                >
-                  <div className="conversation-bubble-head">
-                    <span>{message.role === 'user' ? 'USER' : 'ASSISTANT'}</span>
-                  </div>
-                  <p>{message.content}</p>
-                </article>
-              ))}
-            </div>
-          ) : (
-            <div className="empty-card">当前还没有活跃会话历史。</div>
-          )}
-        </section>
-
-        <section className="hero-panel hero-panel-task">
-          <div className="hero-panel-label">最近任务</div>
-          {heroTask ? (
-            <>
-              <h3>{heroTask.title}</h3>
-              <p>{heroTask.summary || '还没有摘要。'}</p>
-              <div className={`badge badge-${heroTask.state}`}>{stateLabels[heroTask.state]}</div>
-            </>
-          ) : (
-            <div className="empty-card">还没有任务进入系统。</div>
-          )}
-        </section>
+              <strong>{value}</strong>
+              <small>{note}</small>
+            </article>
+          ))}
+        </div>
       </header>
 
-      <section className="metrics-grid">
-        {metrics.map((metric) => (
-          <article className={`metric-card metric-${metric.accent}`} key={metric.label}>
-            <span>{metric.label}</span>
-            <strong>{metric.value}</strong>
-          </article>
-        ))}
+      {error ? <div className="banner-error">接口暂时有点卡住了：{error}</div> : null}
+      {loading ? <div className="banner-hint">正在更新最新状态…</div> : null}
+
+      <section className="dashboard-layout">
+        <div className="dashboard-rail">
+          <TaskListPane tasks={data.tasks} selectedTaskID={selectedTask?.id ?? null} onSelect={(taskID) => {
+            setSelectedTaskId(taskID)
+            setDetailTab('overview')
+          }} />
+        </div>
+
+        <div className="dashboard-stage">
+          <TaskDetailPane
+            artifacts={selectedArtifacts}
+            claudeRecord={claudeRecord}
+            events={selectedEvents}
+            onTabChange={setDetailTab}
+            tab={detailTab}
+            task={selectedTask}
+          />
+
+          <ConversationPane conversation={activeConversation} />
+        </div>
       </section>
-
-      <main className="content-grid">
-        <section className="panel panel-tasks">
-          <div className="panel-head">
-            <div>
-              <p className="eyebrow">TASKS</p>
-              <h2>任务总览</h2>
-            </div>
-            <span className="panel-meta">{loading ? '正在加载' : `每 2 秒刷新 · ${data.tasks.length} 条`}</span>
-          </div>
-
-          {error ? <div className="error-banner">接口异常：{error}</div> : null}
-
-          <div className="task-list">
-            {data.tasks.length === 0 ? (
-              <div className="empty-card">当前还没有任务。先让 XiaoAiAgent 接一个复杂任务试试看。</div>
-            ) : (
-              data.tasks.map((task) => (
-                <article
-                  className={`task-card ${selectedTask?.id === task.id ? 'task-card-selected' : ''}`}
-                  key={task.id}
-                  onClick={() => setSelectedTaskId(task.id)}
-                  role="button"
-                  tabIndex={0}
-                  onKeyDown={(event) => {
-                    if (event.key === 'Enter' || event.key === ' ') {
-                      event.preventDefault()
-                      setSelectedTaskId(task.id)
-                    }
-                  }}
-                >
-                  <div className="task-card-head">
-                    <div>
-                      <p className="task-title">{task.title}</p>
-                      <p className="task-input">{task.input || '没有原始输入。'}</p>
-                    </div>
-                    <span className={`badge badge-${task.state}`}>{stateLabels[task.state]}</span>
-                  </div>
-
-                  <div className="task-card-body">
-                    <div className="task-meta">
-                      <span>摘要</span>
-                      <p>{task.summary || '暂无摘要。'}</p>
-                    </div>
-                    {task.result ? (
-                      <div className="task-meta">
-                        <span>结果</span>
-                        <p>{task.result}</p>
-                      </div>
-                    ) : null}
-                  </div>
-
-                  <div className="task-card-foot">
-                    <span>{task.id}</span>
-                    <span>{formatTime(task.updated_at)}</span>
-                  </div>
-                </article>
-              ))
-            )}
-          </div>
-        </section>
-
-        <aside className="panel panel-side">
-          <section className="focus-card settings-card">
-            <div className="focus-card-head">
-              <div>
-                <p className="eyebrow">SESSION SETTINGS</p>
-                <h3>会话窗口</h3>
-                <p>当前只保留滑动窗口策略。这里控制最近活跃多久后，系统才把上下文切到新会话。</p>
-              </div>
-              <a className="settings-jump" href="#/settings">
-                去系统设置
-              </a>
-            </div>
-
-            <div className="settings-form">
-              <label className="settings-field">
-                <span>会话窗口秒数</span>
-                <input
-                  className="settings-input"
-                  inputMode="numeric"
-                  min={30}
-                  max={3600}
-                  step={1}
-                  type="number"
-                  value={windowInput}
-                  onChange={(event) => {
-                    setWindowInput(event.target.value)
-                    setWindowDirty(true)
-                    setSettingsFeedback(null)
-                    setSettingsError(null)
-                  }}
-                />
-              </label>
-
-              <div className="settings-actions">
-                <button
-                  className="settings-button"
-                  disabled={settingsSaving || !windowDirty}
-                  onClick={() => void saveSessionWindowSettings()}
-                  type="button"
-                >
-                  {settingsSaving ? '保存中...' : '保存设置'}
-                </button>
-                <span className="settings-note">建议范围 30 - 3600 秒，默认值 300 秒。</span>
-              </div>
-
-              {settingsFeedback ? <div className="settings-feedback">{settingsFeedback}</div> : null}
-              {settingsError ? <div className="error-banner settings-error">{settingsError}</div> : null}
-            </div>
-          </section>
-
-          <section className="timeline-card">
-            <div className="panel-head compact">
-              <div>
-                <p className="eyebrow">FOCUS</p>
-                <h2>任务详情</h2>
-              </div>
-              {selectedTask ? (
-                <span className="panel-meta">
-                  {selectedEvents.length} 条事件 · {stateLabels[selectedTask.state]}
-                </span>
-              ) : null}
-            </div>
-
-            {selectedTask ? (
-              <>
-                <article className="focus-card">
-                  <div className="focus-card-head">
-                    <div>
-                      <h3>{selectedTask.title}</h3>
-                      <p>{selectedTask.input || '没有原始输入。'}</p>
-                    </div>
-                    <span className={`badge badge-${selectedTask.state}`}>{stateLabels[selectedTask.state]}</span>
-                  </div>
-
-                  <div className="focus-grid">
-                    <div className="task-meta">
-                      <span>任务摘要</span>
-                      <p>{selectedTask.summary || '暂无摘要。'}</p>
-                    </div>
-                    <div className="task-meta">
-                      <span>最近更新时间</span>
-                      <p>{formatTime(selectedTask.updated_at)}</p>
-                    </div>
-                    {selectedTask.result ? (
-                      <div className="task-meta task-meta-wide">
-                        <span>最终结果</span>
-                        <p>{selectedTask.result}</p>
-                      </div>
-                    ) : null}
-                  </div>
-                </article>
-
-                <article className="focus-card">
-                  <div className="focus-card-head">
-                    <div>
-                      <p className="eyebrow">TASK ARTIFACTS</p>
-                      <h3>任务产物</h3>
-                    </div>
-                    <span className="panel-meta">{selectedArtifacts.length} 个文件</span>
-                  </div>
-
-                  {selectedArtifacts.length > 0 ? (
-                    <div className="focus-grid">
-                      {selectedArtifacts.map((artifact) => (
-                        <div className="task-meta task-meta-wide" key={artifact.id}>
-                          <span>{artifact.kind}{artifact.deliver ? ' · 已标记交付' : ''}</span>
-                          <p>{artifact.file_name}</p>
-                          <p>{artifact.mime_type || 'application/octet-stream'} · {formatBytes(artifact.size_bytes)} · {formatTime(artifact.created_at)}</p>
-                          <p>
-                            <a
-                              href={`/api/tasks/${encodeURIComponent(artifact.task_id)}/artifacts/${encodeURIComponent(artifact.id)}/download`}
-                            >
-                              下载产物
-                            </a>
-                          </p>
-                        </div>
-                      ))}
-                    </div>
-                  ) : (
-                    <div className="empty-card">这个任务当前还没有产物。</div>
-                  )}
-                </article>
-
-                <article className="focus-card focus-card-plugin">
-                  <div className="focus-card-head">
-                    <div>
-                      <p className="eyebrow">CLAUDE PLUGIN</p>
-                      <h3>插件调用记录</h3>
-                    </div>
-                    {claudeRecord ? (
-                      <span className={`badge badge-${claudeRecord.status}`}>{stateLabels[claudeRecord.status]}</span>
-                    ) : null}
-                  </div>
-
-                  {claudeRecord ? (
-                    <div className="focus-grid">
-                      <div className="task-meta">
-                        <span>Claude Session</span>
-                        <p><code>{claudeRecord.session_id || '尚未建立'}</code></p>
-                      </div>
-                      <div className="task-meta">
-                        <span>工作目录</span>
-                        <p>{claudeRecord.working_directory || '—'}</p>
-                      </div>
-                      <div className="task-meta task-meta-wide">
-                        <span>任务提示词</span>
-                        <p>{claudeRecord.prompt || '—'}</p>
-                      </div>
-                      <div className="task-meta">
-                        <span>最新摘要</span>
-                        <p>{claudeRecord.last_summary || '暂无摘要。'}</p>
-                      </div>
-                      <div className="task-meta">
-                        <span>最近记录时间</span>
-                        <p>{formatTime(claudeRecord.updated_at)}</p>
-                      </div>
-                      {claudeRecord.last_assistant_text ? (
-                        <div className="task-meta task-meta-wide">
-                          <span>最近输出</span>
-                          <p>{claudeRecord.last_assistant_text}</p>
-                        </div>
-                      ) : null}
-                      {claudeRecord.error ? (
-                        <div className="task-meta task-meta-wide">
-                          <span>错误</span>
-                          <p>{claudeRecord.error}</p>
-                        </div>
-                      ) : null}
-                    </div>
-                  ) : (
-                    <div className="empty-card">这个任务还没有 Claude 插件记录。</div>
-                  )}
-                </article>
-
-                <div className="timeline">
-                  {selectedEvents.length === 0 ? (
-                    <div className="empty-card">这个任务还没有事件流。</div>
-                  ) : (
-                    selectedEvents.map((event) => (
-                      <article className="timeline-item" key={event.id}>
-                        <span className="timeline-dot" />
-                        <div>
-                          <div className="timeline-head">
-                            <strong>{event.type}</strong>
-                            <span>{formatTime(event.created_at)}</span>
-                          </div>
-                          <p>{event.message}</p>
-                        </div>
-                      </article>
-                    ))
-                  )}
-                </div>
-              </>
-            ) : (
-              <div className="empty-card">还没有任务，右侧暂时没有焦点内容。</div>
-            )}
-          </section>
-        </aside>
-      </main>
-    </>
+    </main>
   )
 }

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -1,4 +1,8 @@
+import { AlertCircle, Clock3, RefreshCw, ScrollText } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
+import { EmptyState } from '../components/ui/EmptyState'
+import { PillTabs } from '../components/ui/PillTabs'
+import { SectionCard } from '../components/ui/SectionCard'
 import { fetchLogsPage } from '../lib/api'
 import { formatTime } from '../lib/dashboard'
 import type { LogEntry, LogPage } from '../types'
@@ -18,6 +22,12 @@ const levelLabels: Record<LogEntry['level'], string> = {
   error: '错误',
   fatal: '致命',
 }
+
+const sizeTabs = [
+  { key: '20', label: '20 条', caption: '更轻' },
+  { key: '50', label: '50 条', caption: '默认' },
+  { key: '100', label: '100 条', caption: '更密' },
+] as const
 
 export function LogsPage() {
   const [page, setPage] = useState(1)
@@ -66,8 +76,6 @@ export function LogsPage() {
     return Math.max(1, Math.ceil(data.total / data.page_size))
   }, [data.page_size, data.total])
 
-  const latestLog = data.items[0] ?? null
-
   async function refreshNow() {
     try {
       setLoading(true)
@@ -82,113 +90,94 @@ export function LogsPage() {
   }
 
   return (
-    <main className="logs-page">
-      <section className="settings-hero-card logs-hero-card">
-        <div>
-          <p className="eyebrow">BACKEND LOGS</p>
-          <h2>后端日志中心</h2>
-          <p className="hero-text">
-            这里只看 Go server 的运行日志。日志会带上时间、源文件和原始消息，适合直接把当前页交给 AI 辅助排查。
-          </p>
+    <main className="page-shell logs-shell">
+      <header className="page-hero">
+        <div className="page-hero-copy">
+          <p className="section-eyebrow">QUIET TRACE</p>
+          <h2>把后端的每一步脚印摊开看，但不要把页面弄得吵闹</h2>
+          <p>日志页只做三件事：切分页、看当前页、在第一页时自动跟着刷新。排查时不再被过重的装饰打断。</p>
         </div>
-        <div className="settings-hero-stats">
-          <div className="metric-card metric-cyan">
-            <span>总日志数</span>
+
+        <div className="hero-metrics">
+          <article className="hero-metric hero-metric-peach">
+            <span><ScrollText size={16} /> 总日志</span>
             <strong>{data.total}</strong>
-          </div>
-          <div className="metric-card metric-amber">
-            <span>当前分页</span>
-            <strong>
-              {data.page} / {pageCount}
-            </strong>
-          </div>
-          <div className="metric-card metric-mint">
-            <span>最新来源</span>
-            <strong>{latestLog?.source || '—'}</strong>
-          </div>
+            <small>已经落库的记录数</small>
+          </article>
+          <article className="hero-metric hero-metric-mint">
+            <span><Clock3 size={16} /> 当前页</span>
+            <strong>{data.page} / {pageCount}</strong>
+            <small>翻页时不会自动跳动</small>
+          </article>
+          <article className="hero-metric hero-metric-sky">
+            <span><AlertCircle size={16} /> 当前页条数</span>
+            <strong>{data.items.length}</strong>
+            <small>倒序紧凑展示</small>
+          </article>
         </div>
-      </section>
+      </header>
 
-      <section className="panel logs-toolbar">
-        <div className="panel-head compact">
-          <div>
-            <p className="eyebrow">LOG CONTROLS</p>
-            <h3>分页浏览</h3>
-          </div>
-        </div>
+      {error ? <div className="banner-error">日志接口现在有点不顺：{error}</div> : null}
 
-        <div className="settings-actions">
-          <label className="settings-field logs-size-field">
-            <span>每页条数</span>
-            <select
-              className="settings-select"
-              value={pageSize}
-              onChange={(event) => {
-                setPageSize(Number(event.target.value))
+      <section className="logs-layout">
+        <SectionCard
+          actions={(
+            <button className="icon-button" disabled={loading} onClick={() => void refreshNow()} type="button">
+              <RefreshCw size={16} />
+              {loading ? '刷新中' : '刷新当前页'}
+            </button>
+          )}
+          className="logs-toolbar-card"
+          description="第一页会自动刷新；翻到别页时会停下来，让你安静看完。"
+          eyebrow="LOG CONTROL"
+          title="分页与刷新"
+        >
+          <div className="logs-toolbar-body">
+            <PillTabs
+              tabs={sizeTabs.map((tab) => ({ ...tab }))}
+              value={String(pageSize) as (typeof sizeTabs)[number]['key']}
+              onChange={(value) => {
+                setPageSize(Number(value))
                 setPage(1)
               }}
-            >
-              <option value={20}>20</option>
-              <option value={50}>50</option>
-              <option value={100}>100</option>
-            </select>
-          </label>
+            />
 
-          <button className="ghost-button" disabled={loading} onClick={() => void refreshNow()} type="button">
-            {loading ? '加载中...' : '刷新当前页'}
-          </button>
-
-          <span className="settings-note">
-            第 1 页会自动刷新，其它页保持静态，避免你翻页排障时被新日志打断。
-          </span>
-        </div>
-
-        <div className="settings-actions">
-          <button className="ghost-button" disabled={page <= 1 || loading} onClick={() => setPage((current) => current - 1)} type="button">
-            上一页
-          </button>
-          <button
-            className="ghost-button"
-            disabled={!data.has_more || loading}
-            onClick={() => setPage((current) => current + 1)}
-            type="button"
-          >
-            下一页
-          </button>
-          <span className="panel-meta">
-            {loading ? '正在加载日志...' : `本页 ${data.items.length} 条`}
-          </span>
-        </div>
-      </section>
-
-      {error ? <div className="error-banner logs-error-banner">日志接口异常：{error}</div> : null}
-
-      <section className="panel logs-stream">
-        <div className="panel-head compact">
-          <div>
-            <p className="eyebrow">LOG STREAM</p>
-            <h3>紧凑日志流</h3>
+            <div className="logs-pagination">
+              <button className="secondary-button" disabled={page <= 1 || loading} onClick={() => setPage((current) => current - 1)} type="button">
+                上一页
+              </button>
+              <span>第 {page} 页</span>
+              <button className="secondary-button" disabled={!data.has_more || loading} onClick={() => setPage((current) => current + 1)} type="button">
+                下一页
+              </button>
+            </div>
           </div>
-          <span className="panel-meta">按时间倒序展示，适合连续排查。</span>
-        </div>
+        </SectionCard>
 
-        {data.items.length === 0 ? (
-          <div className="empty-card">当前还没有后端日志。</div>
-        ) : (
-          <div className="logs-stream-list">
-            {data.items.map((item) => (
-              <article className="log-row" key={item.id}>
-                <div className="log-row-primary">
-                  <span className={`badge badge-log badge-log-${item.level}`}>{levelLabels[item.level]}</span>
-                  <span className="panel-meta">{formatTime(item.created_at)}</span>
-                  <code className="log-source">{item.source || 'unknown'}</code>
-                </div>
-                <p className="log-row-message">{item.message || '—'}</p>
-                <code className="log-row-raw">{item.raw}</code>
-              </article>
-            ))}
-          </div>
-        )}
+        <SectionCard
+          className="logs-stream-card"
+          description="按时间倒序紧凑排布，适合复制给人或 AI 继续排查。"
+          eyebrow="LIVE STRIP"
+          title="后端日志流"
+        >
+          {data.items.length === 0 ? (
+            <EmptyState title="还没有后端日志" description="等后端开始跑起来，这里就会慢慢积累每一条记录。" />
+          ) : (
+            <div className="logs-stream-list">
+              {data.items.map((item) => (
+                <article className="log-line" key={item.id}>
+                  <div className="log-line-head">
+                    <span className={`log-level log-level-${item.level}`}>{levelLabels[item.level]}</span>
+                    <span>{formatTime(item.created_at)}</span>
+                    <code>{item.source || 'unknown'}</code>
+                  </div>
+                  <p className="log-line-message">{item.message || '—'}</p>
+                  <code className="log-line-raw">{item.raw}</code>
+                </article>
+              ))}
+            </div>
+          )}
+        </SectionCard>
       </section>
     </main>
   )

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,3 +1,4 @@
+import { BellRing, MessageSquareHeart, Settings2, SmartphoneCharging } from 'lucide-react'
 import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react'
 import { IMDebugSendPanel } from '../components/settings/IMDebugSendPanel'
 import { IMDeliveryPanel } from '../components/settings/IMDeliveryPanel'
@@ -5,6 +6,9 @@ import { IMTargetsPanel } from '../components/settings/IMTargetsPanel'
 import { SessionSettingsPanel } from '../components/settings/SessionSettingsPanel'
 import { WeChatAccountsPanel } from '../components/settings/WeChatAccountsPanel'
 import { WeChatLoginPanel } from '../components/settings/WeChatLoginPanel'
+import { EmptyState } from '../components/ui/EmptyState'
+import { PillTabs } from '../components/ui/PillTabs'
+import { SectionCard } from '../components/ui/SectionCard'
 import { postFormData, postJSON } from '../lib/api'
 import { normalizeSettings, selectBestTarget } from '../lib/dashboard'
 import type {
@@ -18,12 +22,14 @@ import type {
 } from '../types'
 
 type SettingsSectionKey = 'system' | 'im'
+type IMViewKey = 'delivery' | 'debug' | 'accounts' | 'targets'
 
 type SettingsSection = {
   key: SettingsSectionKey
   eyebrow: string
   title: string
   description: string
+  Icon: typeof Settings2
 }
 
 type LoginPanelState = {
@@ -59,16 +65,25 @@ const emptyLoginState: LoginPanelState = {
 const settingsSections: SettingsSection[] = [
   {
     key: 'system',
-    eyebrow: 'SYSTEM',
+    eyebrow: 'SYSTEM CARE',
     title: '系统设置',
-    description: '管理会话窗口和全局运行期行为，适合放置 Agent 的基础配置。',
+    description: '把会话节奏和全局行为调成更适合你的日常陪伴方式。',
+    Icon: Settings2,
   },
   {
     key: 'im',
     eyebrow: 'IM GATEWAY',
-    title: 'IM 配置',
-    description: '单独管理微信登录、账号、触达目标和回复镜像，不再与系统设置混排。',
+    title: '触达配置',
+    description: '管理微信账号、默认触达、调试发送，以及后续要发到哪里。',
+    Icon: SmartphoneCharging,
   },
+]
+
+const imViews: Array<{ key: IMViewKey; label: string; caption: string }> = [
+  { key: 'delivery', label: '镜像规则', caption: '自动回复怎么转发' },
+  { key: 'debug', label: '手动调试', caption: '文本 / 图片 / 文件' },
+  { key: 'accounts', label: '微信账号', caption: '扫码与账号管理' },
+  { key: 'targets', label: '触达对象', caption: '谁会收到消息' },
 ]
 
 type Props = {
@@ -80,6 +95,7 @@ type Props = {
 
 export function SettingsPage({ data, error, setData, refresh }: Props) {
   const [activeSection, setActiveSection] = useState<SettingsSectionKey>('system')
+  const [activeIMView, setActiveIMView] = useState<IMViewKey>('delivery')
   const [windowInput, setWindowInput] = useState('300')
   const [windowDirty, setWindowDirty] = useState(false)
   const [settingsSaving, setSettingsSaving] = useState(false)
@@ -240,7 +256,7 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
       }))
       setWindowInput(String(nextSettings.session_window_seconds))
       setWindowDirty(false)
-      setSettingsFeedback('已保存，后续请求会立即按新的滑动窗口秒数生效。')
+      setSettingsFeedback('新的会话窗口已经生效。')
     } catch (err) {
       setSettingsError(err instanceof Error ? err.message : '保存失败')
     } finally {
@@ -250,7 +266,7 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
 
   async function saveDeliverySettings() {
     if (deliveryEnabled && (!deliveryAccountID || !deliveryTargetID)) {
-      setDeliveryError('开启镜像前，请先选择一个已经配置好的账号和触达目标。')
+      setDeliveryError('先选好一个账号和一个触达对象，再打开自动镜像。')
       setDeliveryFeedback(null)
       return
     }
@@ -271,7 +287,7 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
         settings: nextSettings,
       }))
       setDeliveryDirty(false)
-      setDeliveryFeedback('IM 文本触达设置已保存。')
+      setDeliveryFeedback('默认触达规则已经保存。')
     } catch (err) {
       setDeliveryError(err instanceof Error ? err.message : '保存失败')
     } finally {
@@ -301,7 +317,7 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
         qrRawText: payload.login.qr_raw_text,
         expiresAt: payload.login.expires_at,
         status: 'pending',
-        message: '请使用微信扫描下方二维码。',
+        message: '请用微信扫描这张二维码。',
         error: null,
         candidate: null,
       })
@@ -338,7 +354,7 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
       })
       await refresh()
       setLoginPanel(emptyLoginState)
-      setDeliveryFeedback('微信账号已添加，你现在可以继续配置触达目标和镜像规则。')
+      setDeliveryFeedback('微信账号已经加入，可以继续配置默认触达。')
       setDeliveryError(null)
     } catch (err) {
       setLoginPanel((current) => ({
@@ -364,7 +380,7 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
       setTargetName('')
       setTargetUserID('')
       setTargetDefault(true)
-      setTargetFeedback('触达目标已保存。')
+      setTargetFeedback('触达对象已经保存。')
       if (!deliveryAccountID) {
         setDeliveryAccountID(targetAccountID)
       }
@@ -382,7 +398,7 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
         target_id: targetID,
       })
       await refresh()
-      setTargetFeedback('默认触达目标已更新。')
+      setTargetFeedback('默认触达对象已经更新。')
       setTargetError(null)
     } catch (err) {
       setTargetError(err instanceof Error ? err.message : '更新默认目标失败')
@@ -390,13 +406,13 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
   }
 
   async function deleteTarget(targetID: string) {
-    if (!window.confirm('确定删除这个触达目标吗？')) return
+    if (!window.confirm('确定删除这个触达对象吗？')) return
     try {
       await postJSON('/api/im/targets/delete', {
         target_id: targetID,
       })
       await refresh()
-      setTargetFeedback('触达目标已删除。')
+      setTargetFeedback('触达对象已删除。')
       setTargetError(null)
     } catch (err) {
       setTargetError(err instanceof Error ? err.message : '删除触达目标失败')
@@ -404,7 +420,7 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
   }
 
   async function deleteAccount(accountID: string) {
-    if (!window.confirm('确定删除这个微信账号吗？这会同时删除它下面的触达目标。')) return
+    if (!window.confirm('确定删除这个微信账号吗？这会同时删除它下面的触达对象。')) return
     try {
       await postJSON('/api/im/accounts/delete', {
         account_id: accountID,
@@ -434,7 +450,7 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
       await refresh()
       setDebugText('')
       if (payload.receipt) {
-        setDebugTextFeedback(`测试消息已发送到 ${payload.receipt.account.display_name || payload.receipt.account.remote_account_id} / ${payload.receipt.target.name}。`)
+        setDebugTextFeedback(`测试消息已发到 ${payload.receipt.target.name}。`)
       } else {
         setDebugTextFeedback('测试消息发送成功。')
       }
@@ -467,7 +483,7 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
       setDebugImageInputKey((current) => current + 1)
       if (result.receipt) {
         const label = result.receipt.media_file_name || debugImageFile.name
-        setDebugImageFeedback(`测试图片 ${label} 已发送到 ${result.receipt.account.display_name || result.receipt.account.remote_account_id} / ${result.receipt.target.name}。`)
+        setDebugImageFeedback(`测试图片 ${label} 已经发出。`)
       } else {
         setDebugImageFeedback('测试图片发送成功。')
       }
@@ -500,7 +516,7 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
       setDebugFileInputKey((current) => current + 1)
       if (result.receipt) {
         const label = result.receipt.media_file_name || debugFileFile.name
-        setDebugFileFeedback(`测试文件 ${label} 已发送到 ${result.receipt.account.display_name || result.receipt.account.remote_account_id} / ${result.receipt.target.name}。`)
+        setDebugFileFeedback(`测试文件 ${label} 已经发出。`)
       } else {
         setDebugFileFeedback('测试文件发送成功。')
       }
@@ -512,72 +528,76 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
   }
 
   return (
-    <main className="settings-page">
-      <section className="settings-hero-card">
-        <div>
-          <p className="eyebrow">SETTINGS CENTER</p>
-          <h2>把设置拆成清晰的配置域</h2>
-          <p className="hero-text">
-            设置页不再把所有配置堆成一个长滚动页面，而是按配置域分开管理。
-            左侧菜单负责切换，右侧只展示当前配置域的内容，让系统设置和 IM 配置各自独立。
-          </p>
+    <main className="page-shell settings-shell">
+      <header className="page-hero">
+        <div className="page-hero-copy">
+          <p className="section-eyebrow">CARE & DELIVERY</p>
+          <h2>把小爱的设置收成舒服、安静、不会乱跑的几个区域</h2>
+          <p>设置页会固定住整体结构。左边选配置域，右边只做当前这件事，不再把所有表单铺成一条长走廊。</p>
         </div>
-        <div className="settings-hero-stats">
-          <div className="metric-card metric-mint">
-            <span>配置域</span>
+
+        <div className="hero-metrics">
+          <article className="hero-metric hero-metric-peach">
+            <span><Settings2 size={16} /> 配置域</span>
             <strong>{settingsSections.length}</strong>
-          </div>
-          <div className="metric-card metric-cyan">
-            <span>微信账号</span>
-            <strong>{data.im.accounts.length}</strong>
-          </div>
-          <div className="metric-card metric-amber">
-            <span>镜像状态</span>
+            <small>系统与触达分开</small>
+          </article>
+          <article className="hero-metric hero-metric-mint">
+            <span><BellRing size={16} /> 自动镜像</span>
             <strong>{data.settings.im_delivery_enabled ? '已开启' : '未开启'}</strong>
-          </div>
+            <small>只影响默认触达</small>
+          </article>
+          <article className="hero-metric hero-metric-sky">
+            <span><MessageSquareHeart size={16} /> 微信账号</span>
+            <strong>{data.im.accounts.length}</strong>
+            <small>已经接入的账号数</small>
+          </article>
         </div>
-      </section>
+      </header>
 
-      {error ? <div className="error-banner">接口异常：{error}</div> : null}
+      {error ? <div className="banner-error">接口暂时有点卡住了：{error}</div> : null}
 
-      <section className="settings-workspace">
-        <aside className="panel settings-nav-card">
-          <div className="panel-head compact">
-            <div>
-              <p className="eyebrow">SETTINGS MAP</p>
-              <h3>配置导航</h3>
+      <section className="settings-layout">
+        <aside className="settings-sidebar">
+          <SectionCard
+            className="settings-menu-card"
+            description="选一个区域，再在右边专心把这件事做好。"
+            eyebrow="SETTINGS MAP"
+            title="配置导航"
+          >
+            <div className="settings-menu-list">
+              {settingsSections.map((section) => {
+                const active = section.key === activeSection
+                const Icon = section.Icon
+                return (
+                  <button
+                    key={section.key}
+                    className={`settings-menu-item ${active ? 'settings-menu-item-active' : ''}`}
+                    onClick={() => setActiveSection(section.key)}
+                    type="button"
+                  >
+                    <span className="settings-menu-item-icon"><Icon size={18} /></span>
+                    <span className="settings-menu-item-copy">
+                      <strong>{section.title}</strong>
+                      <small>{section.description}</small>
+                    </span>
+                  </button>
+                )
+              })}
             </div>
-          </div>
-
-          <div className="settings-nav-list">
-            {settingsSections.map((section) => (
-              <button
-                key={section.key}
-                className={`settings-nav-item ${section.key === activeSection ? 'settings-nav-item-active' : ''}`}
-                onClick={() => setActiveSection(section.key)}
-                type="button"
-              >
-                <span>{section.eyebrow}</span>
-                <strong>{section.title}</strong>
-                <p>{section.description}</p>
-              </button>
-            ))}
-          </div>
+          </SectionCard>
         </aside>
 
         <div className="settings-stage">
-          <section className="panel settings-stage-card">
-            <div className="panel-head compact">
-              <div>
-                <p className="eyebrow">{currentSection.eyebrow}</p>
-                <h3>{currentSection.title}</h3>
-              </div>
-            </div>
-            <p className="settings-stage-copy">{currentSection.description}</p>
-          </section>
+          <SectionCard
+            className="settings-stage-card"
+            description={currentSection.description}
+            eyebrow={currentSection.eyebrow}
+            title={currentSection.title}
+          />
 
           {activeSection === 'system' ? (
-            <section className="settings-grid-page settings-grid-single">
+            <div className="settings-content-single">
               <SessionSettingsPanel
                 settingsError={settingsError}
                 settingsFeedback={settingsFeedback}
@@ -592,121 +612,153 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
                   setSettingsError(null)
                 }}
               />
-            </section>
+
+              <SectionCard
+                className="helper-card"
+                description="会话窗口越长，小爱越容易延续刚刚那段对话；越短，越像重新开始一轮新聊天。"
+                eyebrow="GENTLE TIP"
+                title="怎么理解这个设置"
+              >
+                <div className="helper-points">
+                  <p>日常陪伴型使用可以保留默认值 300 秒。</p>
+                  <p>如果你希望切话题更干脆，可以调短一些。</p>
+                  <p>这里现在只保留滑动窗口策略，不再暴露多余开关。</p>
+                </div>
+              </SectionCard>
+            </div>
           ) : (
-            <section className="settings-grid-page">
-              <IMDeliveryPanel
-                accountID={deliveryAccountID}
-                accounts={deliveryAccounts}
-                dirty={deliveryDirty}
-                enabled={deliveryEnabled}
-                error={deliveryError}
-                feedback={deliveryFeedback}
-                saving={deliverySaving}
-                targetID={deliveryTargetID}
-                targets={deliveryTargets}
-                onAccountChange={(value) => {
-                  setDeliveryAccountID(value)
-                  setDeliveryTargetID(selectBestTarget(data.im.targets, value))
-                  setDeliveryDirty(true)
-                  setDeliveryFeedback(null)
-                  setDeliveryError(null)
-                }}
-                onEnabledChange={(value) => {
-                  setDeliveryEnabled(value)
-                  setDeliveryDirty(true)
-                  setDeliveryFeedback(null)
-                  setDeliveryError(null)
-                }}
-                onSave={() => void saveDeliverySettings()}
-                onTargetChange={(value) => {
-                  setDeliveryTargetID(value)
-                  setDeliveryDirty(true)
-                  setDeliveryFeedback(null)
-                  setDeliveryError(null)
-                }}
-              />
+            <div className="settings-content-stack">
+              <PillTabs tabs={imViews} value={activeIMView} onChange={setActiveIMView} />
 
-              <IMDebugSendPanel
-                account={savedDebugAccount}
-                configDirty={deliveryDirty}
-                imageCaption={debugImageCaption}
-                imageError={debugImageError}
-                imageFeedback={debugImageFeedback}
-                imageFileName={debugImageFile?.name ?? null}
-                imageInputKey={debugImageInputKey}
-                imageSending={debugImageSending}
-                fileCaption={debugFileCaption}
-                fileError={debugFileError}
-                fileFeedback={debugFileFeedback}
-                fileFileName={debugFileFile?.name ?? null}
-                fileInputKey={debugFileInputKey}
-                fileSending={debugFileSending}
-                target={savedDebugTarget}
-                text={debugText}
-                textError={debugTextError}
-                textFeedback={debugTextFeedback}
-                textSending={debugTextSending}
-                onFileCaptionChange={(value) => {
-                  setDebugFileCaption(value)
-                  setDebugFileFeedback(null)
-                  setDebugFileError(null)
-                }}
-                onFileFileChange={(file) => {
-                  setDebugFileFile(file)
-                  setDebugFileFeedback(null)
-                  setDebugFileError(null)
-                }}
-                onSendFile={() => void sendDebugFile()}
-                onImageCaptionChange={(value) => {
-                  setDebugImageCaption(value)
-                  setDebugImageFeedback(null)
-                  setDebugImageError(null)
-                }}
-                onImageFileChange={(file) => {
-                  setDebugImageFile(file)
-                  setDebugImageFeedback(null)
-                  setDebugImageError(null)
-                }}
-                onSendImage={() => void sendDebugImage()}
-                onSendText={() => void sendDebugText()}
-                onTextChange={(value) => {
-                  setDebugText(value)
-                  setDebugTextFeedback(null)
-                  setDebugTextError(null)
-                }}
-              />
+              {activeIMView === 'delivery' ? (
+                <IMDeliveryPanel
+                  accountID={deliveryAccountID}
+                  accounts={deliveryAccounts}
+                  dirty={deliveryDirty}
+                  enabled={deliveryEnabled}
+                  error={deliveryError}
+                  feedback={deliveryFeedback}
+                  saving={deliverySaving}
+                  targetID={deliveryTargetID}
+                  targets={deliveryTargets}
+                  onAccountChange={(value) => {
+                    setDeliveryAccountID(value)
+                    setDeliveryTargetID(selectBestTarget(data.im.targets, value))
+                    setDeliveryDirty(true)
+                    setDeliveryFeedback(null)
+                    setDeliveryError(null)
+                  }}
+                  onEnabledChange={(value) => {
+                    setDeliveryEnabled(value)
+                    setDeliveryDirty(true)
+                    setDeliveryFeedback(null)
+                    setDeliveryError(null)
+                  }}
+                  onSave={() => void saveDeliverySettings()}
+                  onTargetChange={(value) => {
+                    setDeliveryTargetID(value)
+                    setDeliveryDirty(true)
+                    setDeliveryFeedback(null)
+                    setDeliveryError(null)
+                  }}
+                />
+              ) : null}
 
-              <WeChatAccountsPanel
-                accounts={data.im.accounts}
-                loginBusy={loginPanel.open}
-                onDeleteAccount={(accountID) => void deleteAccount(accountID)}
-                onStartLogin={() => void startWeChatLogin()}
-              />
+              {activeIMView === 'debug' ? (
+                <IMDebugSendPanel
+                  account={savedDebugAccount}
+                  configDirty={deliveryDirty}
+                  imageCaption={debugImageCaption}
+                  imageError={debugImageError}
+                  imageFeedback={debugImageFeedback}
+                  imageFileName={debugImageFile?.name ?? null}
+                  imageInputKey={debugImageInputKey}
+                  imageSending={debugImageSending}
+                  fileCaption={debugFileCaption}
+                  fileError={debugFileError}
+                  fileFeedback={debugFileFeedback}
+                  fileFileName={debugFileFile?.name ?? null}
+                  fileInputKey={debugFileInputKey}
+                  fileSending={debugFileSending}
+                  target={savedDebugTarget}
+                  text={debugText}
+                  textError={debugTextError}
+                  textFeedback={debugTextFeedback}
+                  textSending={debugTextSending}
+                  onFileCaptionChange={(value) => {
+                    setDebugFileCaption(value)
+                    setDebugFileFeedback(null)
+                    setDebugFileError(null)
+                  }}
+                  onFileFileChange={(file) => {
+                    setDebugFileFile(file)
+                    setDebugFileFeedback(null)
+                    setDebugFileError(null)
+                  }}
+                  onSendFile={() => void sendDebugFile()}
+                  onImageCaptionChange={(value) => {
+                    setDebugImageCaption(value)
+                    setDebugImageFeedback(null)
+                    setDebugImageError(null)
+                  }}
+                  onImageFileChange={(file) => {
+                    setDebugImageFile(file)
+                    setDebugImageFeedback(null)
+                    setDebugImageError(null)
+                  }}
+                  onSendImage={() => void sendDebugImage()}
+                  onSendText={() => void sendDebugText()}
+                  onTextChange={(value) => {
+                    setDebugText(value)
+                    setDebugTextFeedback(null)
+                    setDebugTextError(null)
+                  }}
+                />
+              ) : null}
 
-              <IMTargetsPanel
-                accountID={targetAccountID}
-                accountTargets={targetFormTargets}
-                accounts={data.im.accounts}
-                error={targetError}
-                feedback={targetFeedback}
-                name={targetName}
-                saving={targetSaving}
-                setDefault={targetDefault}
-                targetUserID={targetUserID}
-                onAccountChange={(value) => {
-                  setTargetAccountID(value)
-                  setTargetFeedback(null)
-                  setTargetError(null)
-                }}
-                onDeleteTarget={(targetID) => void deleteTarget(targetID)}
-                onNameChange={setTargetName}
-                onSave={() => void createTarget()}
-                onSetDefaultChange={setTargetDefault}
-                onSetDefaultTarget={(accountID, targetID) => void setDefaultTarget(accountID, targetID)}
-                onTargetUserIDChange={setTargetUserID}
-              />
-            </section>
+              {activeIMView === 'accounts' ? (
+                <WeChatAccountsPanel
+                  accounts={data.im.accounts}
+                  loginBusy={loginPanel.open}
+                  onDeleteAccount={(accountID) => void deleteAccount(accountID)}
+                  onStartLogin={() => void startWeChatLogin()}
+                />
+              ) : null}
+
+              {activeIMView === 'targets' ? (
+                data.im.accounts.length > 0 ? (
+                  <IMTargetsPanel
+                    accountID={targetAccountID}
+                    accountTargets={targetFormTargets}
+                    accounts={data.im.accounts}
+                    error={targetError}
+                    feedback={targetFeedback}
+                    name={targetName}
+                    saving={targetSaving}
+                    setDefault={targetDefault}
+                    targetUserID={targetUserID}
+                    onAccountChange={(value) => {
+                      setTargetAccountID(value)
+                      setTargetFeedback(null)
+                      setTargetError(null)
+                    }}
+                    onDeleteTarget={(targetID) => void deleteTarget(targetID)}
+                    onNameChange={setTargetName}
+                    onSave={() => void createTarget()}
+                    onSetDefaultChange={setTargetDefault}
+                    onSetDefaultTarget={(accountID, targetID) => void setDefaultTarget(accountID, targetID)}
+                    onTargetUserIDChange={setTargetUserID}
+                  />
+                ) : (
+                  <SectionCard className="helper-card" eyebrow="TARGETS" title="先加一个微信账号">
+                    <EmptyState
+                      title="还没有可配置的账号"
+                      description="先去“微信账号”里扫码接入一个账号，再回来管理默认触达对象。"
+                    />
+                  </SectionCard>
+                )
+              ) : null}
+            </div>
           )}
         </div>
       </section>

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -80,8 +80,8 @@ const settingsSections: SettingsSection[] = [
 ]
 
 const imViews: Array<{ key: IMViewKey; label: string; caption: string }> = [
-  { key: 'delivery', label: '镜像规则', caption: '自动回复怎么转发' },
   { key: 'debug', label: '手动调试', caption: '文本 / 图片 / 文件' },
+  { key: 'delivery', label: '镜像规则', caption: '自动回复怎么转发' },
   { key: 'accounts', label: '微信账号', caption: '扫码与账号管理' },
   { key: 'targets', label: '触达对象', caption: '谁会收到消息' },
 ]
@@ -95,7 +95,7 @@ type Props = {
 
 export function SettingsPage({ data, error, setData, refresh }: Props) {
   const [activeSection, setActiveSection] = useState<SettingsSectionKey>('system')
-  const [activeIMView, setActiveIMView] = useState<IMViewKey>('delivery')
+  const [activeIMView, setActiveIMView] = useState<IMViewKey>('debug')
   const [windowInput, setWindowInput] = useState('300')
   const [windowDirty, setWindowDirty] = useState(false)
   const [settingsSaving, setSettingsSaving] = useState(false)
@@ -628,7 +628,7 @@ export function SettingsPage({ data, error, setData, refresh }: Props) {
             </div>
           ) : (
             <div className="settings-content-stack">
-              <PillTabs tabs={imViews} value={activeIMView} onChange={setActiveIMView} />
+              <PillTabs className="settings-pill-tabs" tabs={imViews} value={activeIMView} onChange={setActiveIMView} />
 
               {activeIMView === 'delivery' ? (
                 <IMDeliveryPanel

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,509 +1,884 @@
+@import url("https://fonts.googleapis.com/css2?family=Baloo+2:wght@600;700;800&family=Nunito:wght@400;600;700;800&display=swap");
+
 :root {
-  color-scheme: dark;
-  font-family: "Avenir Next", "Futura", "Helvetica Neue", sans-serif;
+  color-scheme: light;
+  font-family: "Nunito", "Avenir Next", "Segoe UI", sans-serif;
   background:
-    radial-gradient(circle at top left, rgba(42, 234, 196, 0.2), transparent 36%),
-    radial-gradient(circle at top right, rgba(255, 190, 92, 0.16), transparent 28%),
-    linear-gradient(180deg, #0b1020 0%, #090d18 100%);
-  color: #edf2ff;
+    radial-gradient(circle at top left, rgba(255, 187, 155, 0.44), transparent 28%),
+    radial-gradient(circle at top right, rgba(136, 222, 201, 0.36), transparent 24%),
+    radial-gradient(circle at bottom right, rgba(255, 224, 153, 0.38), transparent 24%),
+    linear-gradient(180deg, #fffaf4 0%, #fff6ef 100%);
+  color: #5a4034;
+  --bg: #fffaf4;
+  --panel: rgba(255, 255, 255, 0.74);
+  --panel-strong: rgba(255, 255, 255, 0.92);
+  --line: rgba(181, 135, 111, 0.16);
+  --line-strong: rgba(181, 135, 111, 0.28);
+  --text-main: #5a4034;
+  --text-soft: #7f6659;
+  --text-faint: #a08475;
+  --peach: #ffb38a;
+  --mint: #89dbc6;
+  --sky: #8bc8ff;
+  --butter: #ffd98e;
+  --rose: #f4a5b9;
+  --danger: #d45b69;
+  --shadow: 0 24px 60px rgba(183, 132, 96, 0.14);
+  --shadow-soft: 0 12px 26px rgba(183, 132, 96, 0.08);
 }
 
 * {
   box-sizing: border-box;
 }
 
+html,
+body,
+#root {
+  height: 100%;
+}
+
+html,
 body {
   margin: 0;
-  min-height: 100vh;
+  overflow: hidden;
+}
+
+body {
   background: transparent;
+  color: var(--text-main);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
 }
 
 code {
-  font-family: "SF Mono", "Menlo", monospace;
-}
-
-#root {
-  min-height: 100vh;
+  font-family: "SFMono-Regular", "SF Mono", "Menlo", monospace;
 }
 
 .app-shell {
   position: relative;
-  min-height: 100vh;
-  padding: 40px 28px 64px;
+  display: grid;
+  grid-template-columns: 288px minmax(0, 1fr);
+  gap: 18px;
+  height: 100dvh;
+  padding: 18px;
   overflow: hidden;
 }
 
-.topbar {
-  position: relative;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 20px;
-  margin: 0 auto 24px;
-  max-width: 1360px;
-}
-
-.topbar-title {
-  margin: 6px 0 0;
-  font-size: 1.6rem;
-  letter-spacing: -0.03em;
-}
-
-.topbar-nav {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  padding: 8px;
-  border-radius: 999px;
-  backdrop-filter: blur(18px);
-  background: rgba(8, 13, 24, 0.72);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-.topbar-link {
-  padding: 10px 16px;
-  border-radius: 999px;
-  color: rgba(237, 242, 255, 0.72);
-  text-decoration: none;
-  transition:
-    background 180ms ease,
-    color 180ms ease;
-}
-
-.topbar-link:hover {
-  color: #edf2ff;
-}
-
-.topbar-link-active {
-  color: #041019;
-  background: linear-gradient(135deg, #2aeac4 0%, #ffc062 100%);
-}
-
-.aurora {
+.app-glow {
   position: absolute;
-  inset: auto;
-  width: 36rem;
-  height: 36rem;
-  filter: blur(100px);
-  opacity: 0.38;
+  border-radius: 999px;
+  filter: blur(60px);
   pointer-events: none;
+  opacity: 0.65;
 }
 
-.aurora-left {
-  top: -10rem;
-  left: -10rem;
-  background: #19d3c5;
+.app-glow-left {
+  top: -120px;
+  left: -80px;
+  width: 260px;
+  height: 260px;
+  background: rgba(255, 179, 138, 0.58);
 }
 
-.aurora-right {
-  top: -4rem;
-  right: -10rem;
-  background: #ff9c5a;
+.app-glow-right {
+  right: -60px;
+  bottom: -100px;
+  width: 300px;
+  height: 300px;
+  background: rgba(137, 219, 198, 0.46);
 }
 
-.hero {
-  position: relative;
-  display: grid;
-  grid-template-columns: minmax(0, 1.4fr) minmax(300px, 420px) minmax(280px, 360px);
-  gap: 24px;
-  margin: 0 auto 28px;
-  max-width: 1360px;
-}
-
-.hero-copy,
-.hero-panel,
+.app-sidebar,
+.app-main,
+.section-card,
 .panel,
-.metric-card,
-.insight-card,
-.timeline-card,
-.task-card {
-  backdrop-filter: blur(18px);
-  background: rgba(8, 13, 24, 0.72);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.32);
+.settings-modal-card {
+  min-width: 0;
 }
 
-.hero-copy {
-  padding: 32px;
-  border-radius: 28px;
-}
-
-.hero-panel {
-  padding: 28px;
-  border-radius: 28px;
-  align-self: stretch;
+.app-sidebar {
+  position: relative;
   display: flex;
   flex-direction: column;
-  justify-content: flex-start;
+  gap: 16px;
+  min-height: 0;
+  padding: 18px;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
 }
 
-.hero-panel-head {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 12px;
-  margin-bottom: 16px;
+.brand-card {
+  position: relative;
+  overflow: hidden;
+  padding: 22px 20px 18px;
+  border-radius: 24px;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.96), rgba(255, 242, 235, 0.92));
+  border: 1px solid rgba(255, 179, 138, 0.24);
+  box-shadow: var(--shadow-soft);
 }
 
-.hero-panel-conversation {
-  min-height: 320px;
+.brand-orb {
+  position: absolute;
+  border-radius: 999px;
+  opacity: 0.8;
 }
 
-.hero-panel-task {
-  justify-content: center;
+.brand-orb-peach {
+  top: -28px;
+  right: -18px;
+  width: 110px;
+  height: 110px;
+  background: rgba(255, 179, 138, 0.38);
 }
 
-.hero-copy h1,
-.hero-copy h2,
-.hero-panel h2,
-.panel h2 {
+.brand-orb-mint {
+  bottom: -30px;
+  left: -26px;
+  width: 92px;
+  height: 92px;
+  background: rgba(137, 219, 198, 0.36);
+}
+
+.brand-kicker,
+.section-eyebrow,
+.page-hero-copy p.section-eyebrow,
+.eyebrow {
   margin: 0;
-  font-weight: 700;
-  letter-spacing: -0.03em;
-}
-
-.hero-copy h1 {
-  font-size: clamp(2.6rem, 7vw, 5.4rem);
-  line-height: 0.95;
-  max-width: 11ch;
-}
-
-.hero-copy h2 {
-  font-size: clamp(2.2rem, 5vw, 4rem);
-  line-height: 1;
-  max-width: 12ch;
-}
-
-.hero-panel h2 {
-  font-size: clamp(1.8rem, 3vw, 2.4rem);
-  margin-top: 8px;
-}
-
-.hero-text,
-.hero-panel p,
-.task-input,
-.task-meta p,
-.timeline-item p,
-.empty-card,
-.error-banner {
-  color: rgba(237, 242, 255, 0.76);
-  line-height: 1.6;
-}
-
-.hero-text {
-  max-width: 56ch;
-  margin-top: 18px;
-}
-
-.hero-panel-label,
-.eyebrow,
-.task-meta span,
-.task-card-foot,
-.panel-meta,
-.timeline-item small {
+  color: var(--text-faint);
   text-transform: uppercase;
   letter-spacing: 0.16em;
   font-size: 0.72rem;
-  color: rgba(237, 242, 255, 0.52);
+  font-weight: 800;
 }
 
-.metrics-grid {
-  position: relative;
-  display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 16px;
-  margin: 0 auto 24px;
-  max-width: 1360px;
+.brand-card h1,
+.page-hero h2,
+.section-title,
+.topbar-title {
+  margin: 0;
+  font-family: "Baloo 2", "Nunito", sans-serif;
+  line-height: 1.02;
+  letter-spacing: -0.03em;
+  color: #5d4137;
 }
 
-.metric-card {
-  padding: 18px 20px;
-  border-radius: 22px;
-}
-
-.metric-card span {
-  display: block;
-  margin-bottom: 10px;
-  font-size: 0.86rem;
-  color: rgba(237, 242, 255, 0.64);
-}
-
-.metric-card strong {
+.brand-card h1 {
+  margin-top: 10px;
   font-size: 2rem;
-  letter-spacing: -0.04em;
 }
 
-.metric-cyan {
-  box-shadow: inset 0 1px 0 rgba(92, 251, 236, 0.3), 0 18px 60px rgba(0, 0, 0, 0.32);
+.brand-card p:last-child {
+  margin: 12px 0 0;
+  max-width: 24ch;
+  color: var(--text-soft);
+  line-height: 1.65;
 }
 
-.metric-amber {
-  box-shadow: inset 0 1px 0 rgba(255, 193, 106, 0.26), 0 18px 60px rgba(0, 0, 0, 0.32);
-}
-
-.metric-mint {
-  box-shadow: inset 0 1px 0 rgba(173, 255, 205, 0.26), 0 18px 60px rgba(0, 0, 0, 0.32);
-}
-
-.metric-rose {
-  box-shadow: inset 0 1px 0 rgba(255, 140, 183, 0.26), 0 18px 60px rgba(0, 0, 0, 0.32);
-}
-
-.metric-violet {
-  box-shadow: inset 0 1px 0 rgba(182, 162, 255, 0.26), 0 18px 60px rgba(0, 0, 0, 0.32);
-}
-
-.content-grid {
-  position: relative;
+.sidebar-nav {
   display: grid;
-  grid-template-columns: minmax(0, 1.5fr) minmax(320px, 0.9fr);
-  gap: 20px;
-  margin: 0 auto;
-  max-width: 1360px;
+  gap: 10px;
 }
 
-.panel,
-.timeline-card,
-.insight-card {
-  border-radius: 28px;
-  padding: 24px;
-}
-
-.panel-head {
+.sidebar-link {
   display: flex;
-  justify-content: space-between;
-  align-items: end;
-  gap: 16px;
-  margin-bottom: 18px;
-}
-
-.panel-head.compact {
-  margin-bottom: 20px;
-}
-
-.task-list,
-.timeline {
-  display: grid;
-  gap: 14px;
-}
-
-.task-card {
-  border-radius: 22px;
-  padding: 18px;
-  cursor: pointer;
-  transition:
-    transform 180ms ease,
-    border-color 180ms ease,
-    background 180ms ease,
-    box-shadow 180ms ease;
-}
-
-.task-card:hover {
-  transform: translateY(-2px);
-  border-color: rgba(42, 234, 196, 0.26);
-}
-
-.task-card-selected {
-  background: linear-gradient(180deg, rgba(14, 24, 39, 0.88), rgba(9, 14, 24, 0.82));
-  border-color: rgba(42, 234, 196, 0.42);
-  box-shadow:
-    inset 0 1px 0 rgba(42, 234, 196, 0.2),
-    0 18px 60px rgba(0, 0, 0, 0.32);
-}
-
-.task-card-head,
-.task-card-foot,
-.timeline-head {
-  display: flex;
-  justify-content: space-between;
-  gap: 14px;
-}
-
-.task-card-head {
-  align-items: start;
-  margin-bottom: 14px;
-}
-
-.task-title {
-  margin: 0;
-  font-size: 1.1rem;
-  font-weight: 600;
-}
-
-.task-input {
-  margin: 6px 0 0;
-}
-
-.task-card-body {
-  display: grid;
+  align-items: center;
   gap: 12px;
+  padding: 14px;
+  border-radius: 22px;
+  border: 1px solid transparent;
+  color: var(--text-soft);
+  transition:
+    transform 160ms ease,
+    background 160ms ease,
+    border-color 160ms ease;
 }
 
-.task-meta span {
-  display: block;
-  margin-bottom: 6px;
+.sidebar-link:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.6);
+  border-color: rgba(255, 179, 138, 0.22);
 }
 
-.task-meta p,
-.timeline-item p {
-  margin: 0;
+.sidebar-link-active {
+  background: linear-gradient(135deg, rgba(255, 226, 207, 0.95), rgba(255, 245, 233, 0.98));
+  border-color: rgba(255, 179, 138, 0.28);
+  color: var(--text-main);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9);
 }
 
-.task-card-foot {
-  margin-top: 16px;
-  padding-top: 14px;
-  border-top: 1px solid rgba(255, 255, 255, 0.07);
-}
-
-.badge {
+.sidebar-link-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 7px 12px;
-  border-radius: 999px;
-  font-size: 0.76rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  border: 1px solid transparent;
+  width: 42px;
+  height: 42px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.75);
+  color: #c67856;
+  border: 1px solid rgba(255, 179, 138, 0.22);
 }
 
-.badge-accepted {
-  color: #ffe7a6;
-  background: rgba(255, 190, 92, 0.14);
-  border-color: rgba(255, 190, 92, 0.32);
-}
-
-.badge-running {
-  color: #93fff3;
-  background: rgba(42, 234, 196, 0.14);
-  border-color: rgba(42, 234, 196, 0.32);
-}
-
-.badge-completed {
-  color: #aeffbf;
-  background: rgba(116, 255, 153, 0.14);
-  border-color: rgba(116, 255, 153, 0.26);
-}
-
-.badge-failed {
-  color: #ffb0c8;
-  background: rgba(255, 112, 162, 0.14);
-  border-color: rgba(255, 112, 162, 0.28);
-}
-
-.badge-canceled {
-  color: #d4caff;
-  background: rgba(166, 135, 255, 0.14);
-  border-color: rgba(166, 135, 255, 0.28);
-}
-
-.badge-log-debug,
-.badge-log-info {
-  color: #93fff3;
-  background: rgba(42, 234, 196, 0.14);
-  border-color: rgba(42, 234, 196, 0.32);
-}
-
-.badge-log-warn {
-  color: #ffe7a6;
-  background: rgba(255, 190, 92, 0.14);
-  border-color: rgba(255, 190, 92, 0.32);
-}
-
-.badge-log-error,
-.badge-log-fatal {
-  color: #ffb0c8;
-  background: rgba(255, 112, 162, 0.14);
-  border-color: rgba(255, 112, 162, 0.28);
-}
-
-.timeline-item {
-  position: relative;
+.sidebar-link-copy {
   display: grid;
-  grid-template-columns: 16px minmax(0, 1fr);
+  gap: 2px;
+}
+
+.sidebar-link-copy strong {
+  font-size: 1rem;
+}
+
+.sidebar-link-copy small {
+  color: var(--text-faint);
+}
+
+.sidebar-stats {
+  margin-top: auto;
+  display: grid;
+  gap: 10px;
+}
+
+.mini-stat {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 12px;
-  padding: 6px 0;
-}
-
-.timeline-dot {
-  display: inline-block;
-  width: 12px;
-  height: 12px;
-  margin-top: 7px;
-  border-radius: 50%;
-  background: linear-gradient(135deg, #2aeac4 0%, #ffc062 100%);
-  box-shadow: 0 0 0 5px rgba(42, 234, 196, 0.12);
-}
-
-.timeline-head {
-  align-items: baseline;
-  margin-bottom: 6px;
-}
-
-.timeline-head strong {
-  font-size: 0.96rem;
-}
-
-.empty-card,
-.error-banner {
-  padding: 18px 20px;
+  padding: 14px 16px;
   border-radius: 20px;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.07);
+  border: 1px solid var(--line);
+  background: var(--panel);
 }
 
-.error-banner {
-  margin-bottom: 14px;
-  color: #ffc4cf;
-  border-color: rgba(255, 112, 162, 0.28);
+.mini-stat span,
+.hero-metric span {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-soft);
+  font-weight: 700;
 }
 
-.panel-side {
-  display: grid;
-  gap: 20px;
+.mini-stat strong,
+.hero-metric strong {
+  font-family: "Baloo 2", "Nunito", sans-serif;
+  font-size: 1.6rem;
+  line-height: 1;
 }
 
-.settings-card {
-  margin-bottom: 0;
+.mini-stat-peach {
+  box-shadow: inset 0 1px 0 rgba(255, 179, 138, 0.26);
 }
 
-.focus-card {
-  margin-bottom: 18px;
+.mini-stat-mint {
+  box-shadow: inset 0 1px 0 rgba(137, 219, 198, 0.28);
+}
+
+.app-main {
+  position: relative;
+  min-height: 0;
+  overflow: hidden;
+  border-radius: 34px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.54);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+}
+
+.page-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  height: 100%;
   padding: 18px;
-  border-radius: 22px;
-  background: linear-gradient(160deg, rgba(18, 31, 54, 0.92), rgba(11, 17, 31, 0.76));
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  min-height: 0;
+  overflow: hidden;
 }
 
-.focus-card-head {
+.page-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(280px, 0.85fr);
+  gap: 16px;
+}
+
+.page-hero-copy,
+.hero-metrics,
+.section-card,
+.panel,
+.settings-modal-card {
+  border-radius: 28px;
+  border: 1px solid var(--line);
+  background: var(--panel);
+  backdrop-filter: blur(14px);
+  box-shadow: var(--shadow-soft);
+}
+
+.page-hero-copy {
+  padding: 24px 26px;
+  display: grid;
+  gap: 12px;
+}
+
+.page-hero h2 {
+  font-size: clamp(2rem, 3vw, 3rem);
+}
+
+.page-hero-copy p:last-child {
+  margin: 0;
+  max-width: 50ch;
+  line-height: 1.75;
+  color: var(--text-soft);
+}
+
+.hero-metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  padding: 14px;
+}
+
+.hero-metric {
+  padding: 16px;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.8);
+  display: grid;
+  gap: 8px;
+}
+
+.hero-metric small {
+  color: var(--text-faint);
+  line-height: 1.4;
+}
+
+.hero-metric-peach {
+  box-shadow: inset 0 1px 0 rgba(255, 179, 138, 0.3);
+}
+
+.hero-metric-mint {
+  box-shadow: inset 0 1px 0 rgba(137, 219, 198, 0.34);
+}
+
+.hero-metric-sky {
+  box-shadow: inset 0 1px 0 rgba(139, 200, 255, 0.32);
+}
+
+.hero-metric-butter {
+  box-shadow: inset 0 1px 0 rgba(255, 217, 142, 0.34);
+}
+
+.banner-error,
+.banner-hint,
+.settings-feedback,
+.error-banner {
+  padding: 14px 16px;
+  border-radius: 18px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.76);
+  color: var(--text-soft);
+}
+
+.banner-error,
+.error-banner {
+  border-color: rgba(212, 91, 105, 0.26);
+  color: #a84f5b;
+  background: rgba(255, 244, 245, 0.92);
+}
+
+.banner-hint {
+  color: #7c6b5d;
+}
+
+.dashboard-layout,
+.settings-layout,
+.logs-layout {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  gap: 16px;
+}
+
+.dashboard-layout {
+  grid-template-columns: 360px minmax(0, 1fr);
+}
+
+.dashboard-rail,
+.settings-sidebar,
+.dashboard-stage,
+.settings-stage {
+  min-height: 0;
+}
+
+.dashboard-rail {
+  display: flex;
+  flex-direction: column;
+}
+
+.dashboard-stage {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) minmax(250px, 0.78fr);
+  gap: 16px;
+  min-height: 0;
+}
+
+.section-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  padding: 18px;
+}
+
+.section-card-head {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.section-card-copy {
+  display: grid;
+  gap: 6px;
+}
+
+.section-title {
+  font-size: 1.72rem;
+}
+
+.section-description {
+  margin: 0;
+  color: var(--text-soft);
+  line-height: 1.65;
+}
+
+.section-card-body {
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.task-list-stack,
+.timeline-stack,
+.logs-stream-list,
+.artifact-list,
+.conversation-bubbles,
+.settings-menu-list {
+  display: grid;
+  gap: 12px;
+}
+
+.dashboard-rail-card .section-card-body,
+.logs-stream-card .section-card-body,
+.dashboard-main-card .section-card-body,
+.conversation-card .section-card-body,
+.settings-menu-card .section-card-body {
+  overflow: auto;
+  min-height: 0;
+  padding-right: 2px;
+}
+
+.task-teaser {
+  text-align: left;
+  display: grid;
+  gap: 12px;
+  width: 100%;
+  padding: 16px;
+  border-radius: 22px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.76);
+  color: inherit;
+  cursor: pointer;
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.task-teaser:hover {
+  transform: translateY(-1px);
+  border-color: rgba(255, 179, 138, 0.34);
+}
+
+.task-teaser-active {
+  border-color: rgba(255, 179, 138, 0.46);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.88);
+  background: linear-gradient(180deg, rgba(255, 248, 244, 0.96), rgba(255, 241, 234, 0.88));
+}
+
+.task-teaser-head,
+.artifact-card-head,
+.timeline-bubble-head,
+.conversation-summary,
+.task-teaser-meta,
+.artifact-card-meta,
+.task-card-foot,
+.panel-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.task-teaser-copy {
+  display: grid;
+  gap: 6px;
+}
+
+.task-teaser-copy strong,
+.artifact-card-copy strong,
+.chat-bubble strong,
+.task-title {
+  font-size: 1rem;
+  color: var(--text-main);
+}
+
+.task-teaser-copy p,
+.artifact-card-copy p,
+.timeline-bubble p,
+.chat-bubble p,
+.task-input,
+.task-meta p,
+.soft-panel p,
+.helper-points p,
+.empty-state p,
+.log-line-message {
+  margin: 0;
+  color: var(--text-soft);
+  line-height: 1.65;
+}
+
+.task-teaser-meta,
+.artifact-card-meta,
+.conversation-summary,
+.log-line-head,
+.panel-meta,
+.settings-note {
+  color: var(--text-faint);
+  font-size: 0.9rem;
+}
+
+.task-teaser-meta span,
+.artifact-card-meta span,
+.conversation-summary span,
+.soft-panel-head,
+.settings-menu-item-icon {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.status-badge,
+.soft-chip,
+.log-level {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 7px 10px;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 800;
+  border: 1px solid transparent;
+}
+
+.status-accepted {
+  color: #8d653c;
+  background: rgba(255, 217, 142, 0.28);
+  border-color: rgba(255, 217, 142, 0.48);
+}
+
+.status-running {
+  color: #1f8470;
+  background: rgba(137, 219, 198, 0.24);
+  border-color: rgba(137, 219, 198, 0.48);
+}
+
+.status-completed {
+  color: #5f7b26;
+  background: rgba(205, 235, 151, 0.32);
+  border-color: rgba(205, 235, 151, 0.5);
+}
+
+.status-failed,
+.status-canceled {
+  color: #b15561;
+  background: rgba(244, 165, 185, 0.24);
+  border-color: rgba(244, 165, 185, 0.48);
+}
+
+.soft-chip {
+  color: #bb6d51;
+  background: rgba(255, 243, 237, 0.92);
+  border-color: rgba(255, 179, 138, 0.3);
+}
+
+.soft-chip-peach {
+  background: rgba(255, 239, 229, 0.96);
+}
+
+.pill-tabs {
+  display: flex;
+  gap: 10px;
+  overflow: auto;
+  padding-bottom: 2px;
+}
+
+.pill-tab {
+  display: grid;
+  gap: 2px;
+  min-width: 120px;
+  padding: 12px 14px;
+  border-radius: 20px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.74);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+
+.pill-tab strong {
+  font-size: 0.96rem;
+}
+
+.pill-tab span {
+  color: var(--text-faint);
+  font-size: 0.84rem;
+}
+
+.pill-tab-active {
+  border-color: rgba(255, 179, 138, 0.36);
+  background: linear-gradient(180deg, rgba(255, 248, 242, 1), rgba(255, 239, 229, 0.94));
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.soft-panel,
+.artifact-card,
+.timeline-bubble,
+.chat-bubble,
+.account-card,
+.target-card,
+.log-line,
+.empty-state,
+.empty-card,
+.helper-card .section-card-body,
+.settings-nav-item {
+  border-radius: 22px;
+  border: 1px solid var(--line);
+  background: var(--panel-strong);
+}
+
+.soft-panel,
+.artifact-card,
+.timeline-bubble,
+.chat-bubble,
+.account-card,
+.target-card,
+.log-line,
+.empty-state,
+.empty-card {
+  padding: 16px;
+}
+
+.soft-panel-head {
+  color: var(--text-main);
+  font-weight: 800;
+  margin-bottom: 10px;
+}
+
+.fact-list {
+  display: grid;
+  gap: 10px;
+}
+
+.fact-list div {
+  display: grid;
+  gap: 2px;
+}
+
+.fact-list dt {
+  font-size: 0.82rem;
+  color: var(--text-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.fact-list dd {
+  margin: 0;
+  color: var(--text-soft);
+  line-height: 1.5;
+  word-break: break-word;
+}
+
+.artifact-card {
+  display: grid;
+  gap: 12px;
+}
+
+.action-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  width: fit-content;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(255, 248, 242, 0.96);
+  color: #bb6d51;
+  font-weight: 800;
+}
+
+.timeline-bubble {
+  display: grid;
+  gap: 8px;
+}
+
+.timeline-bubble-head span {
+  color: var(--text-faint);
+  font-size: 0.88rem;
+}
+
+.conversation-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+}
+
+.conversation-bubbles {
+  overflow: auto;
+  min-height: 0;
+  padding-right: 2px;
+}
+
+.chat-bubble {
+  display: grid;
+  gap: 8px;
+}
+
+.chat-bubble-user {
+  background: rgba(255, 245, 235, 0.96);
+}
+
+.chat-bubble-assistant {
+  background: rgba(245, 255, 252, 0.96);
+}
+
+.inline-error {
+  color: #aa5360;
+}
+
+.empty-state {
+  display: grid;
+  gap: 8px;
+}
+
+.empty-state strong {
+  font-family: "Baloo 2", "Nunito", sans-serif;
+  font-size: 1.3rem;
+}
+
+.settings-layout {
+  grid-template-columns: 280px minmax(0, 1fr);
+}
+
+.settings-sidebar,
+.settings-stage,
+.logs-layout {
+  min-height: 0;
+}
+
+.settings-stage {
+  display: flex;
+  flex-direction: column;
   gap: 16px;
+  min-height: 0;
+}
+
+.settings-content-single,
+.settings-content-stack {
+  min-height: 0;
+  display: grid;
+  gap: 16px;
+  overflow: auto;
+  padding-right: 2px;
+}
+
+.settings-content-single {
+  grid-template-columns: minmax(0, 1fr) 280px;
+}
+
+.settings-menu-list {
+  grid-auto-rows: minmax(0, auto);
+}
+
+.settings-menu-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  text-align: left;
+  width: 100%;
+  padding: 14px;
+  cursor: pointer;
+  color: inherit;
+  transition: border-color 160ms ease, transform 160ms ease;
+}
+
+.settings-menu-item:hover {
+  transform: translateY(-1px);
+  border-color: rgba(255, 179, 138, 0.34);
+}
+
+.settings-menu-item-active {
+  border-color: rgba(255, 179, 138, 0.42);
+  background: linear-gradient(180deg, rgba(255, 248, 242, 0.98), rgba(255, 239, 229, 0.94));
+}
+
+.settings-menu-item-copy {
+  display: grid;
+  gap: 4px;
+}
+
+.settings-menu-item-copy small {
+  color: var(--text-faint);
+  line-height: 1.5;
+}
+
+.settings-panel,
+.panel {
+  padding: 18px;
+  background: var(--panel);
+}
+
+.panel-head.compact {
   margin-bottom: 16px;
 }
 
-.focus-card-head h3 {
-  margin: 0;
-  font-size: 1.5rem;
-  letter-spacing: -0.03em;
-}
-
-.focus-card-head p {
-  margin: 8px 0 0;
-  color: rgba(237, 242, 255, 0.74);
-  line-height: 1.6;
-}
-
-.focus-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 14px;
-}
-
-.settings-form {
+.settings-form,
+.target-editor {
   display: grid;
   gap: 14px;
+}
+
+.target-editor {
+  grid-template-columns: minmax(280px, 380px) minmax(0, 1fr);
+  align-items: flex-start;
 }
 
 .settings-field {
@@ -511,588 +886,337 @@ code {
   gap: 8px;
 }
 
-.settings-field span,
-.settings-note {
-  color: rgba(237, 242, 255, 0.66);
-  line-height: 1.6;
+.settings-field > span:first-child {
+  color: var(--text-main);
+  font-weight: 700;
 }
 
 .settings-input,
+.settings-select,
 .settings-textarea {
   width: 100%;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 16px;
-  padding: 14px 16px;
-  color: #edf2ff;
-  background: rgba(5, 11, 20, 0.86);
-  font: inherit;
-}
-
-.settings-textarea {
+  border-radius: 18px;
+  border: 1px solid var(--line-strong);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--text-main);
+  padding: 12px 14px;
+  outline: none;
   resize: vertical;
-  min-height: 112px;
 }
 
 .settings-input:focus,
+.settings-select:focus,
 .settings-textarea:focus {
-  outline: none;
-  border-color: rgba(42, 234, 196, 0.46);
-  box-shadow: 0 0 0 4px rgba(42, 234, 196, 0.08);
-}
-
-.settings-select {
-  width: 100%;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 16px;
-  padding: 14px 16px;
-  color: #edf2ff;
-  background: rgba(5, 11, 20, 0.86);
-  font: inherit;
-}
-
-.settings-select:focus {
-  outline: none;
-  border-color: rgba(42, 234, 196, 0.46);
-  box-shadow: 0 0 0 4px rgba(42, 234, 196, 0.08);
-}
-
-.settings-actions {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 12px;
-}
-
-.settings-button {
-  border: 0;
-  border-radius: 999px;
-  padding: 12px 18px;
-  color: #041019;
-  background: linear-gradient(135deg, #2aeac4 0%, #ffc062 100%);
-  font: inherit;
-  font-weight: 700;
-  cursor: pointer;
-  transition:
-    transform 180ms ease,
-    opacity 180ms ease;
-}
-
-.settings-button:hover:not(:disabled) {
-  transform: translateY(-1px);
-}
-
-.settings-button:disabled {
-  opacity: 0.52;
-  cursor: not-allowed;
-}
-
-.settings-jump,
-.ghost-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 999px;
-  padding: 10px 14px;
-  color: rgba(237, 242, 255, 0.82);
-  background: rgba(255, 255, 255, 0.04);
-  font: inherit;
-  text-decoration: none;
-  cursor: pointer;
-  transition:
-    transform 180ms ease,
-    border-color 180ms ease;
-}
-
-.settings-jump:hover,
-.ghost-button:hover {
-  transform: translateY(-1px);
-  border-color: rgba(42, 234, 196, 0.32);
-}
-
-.ghost-danger:hover {
-  border-color: rgba(255, 112, 162, 0.32);
-}
-
-.settings-feedback {
-  padding: 14px 16px;
-  border-radius: 16px;
-  color: #b8ffe0;
-  background: rgba(42, 234, 196, 0.08);
-  border: 1px solid rgba(42, 234, 196, 0.18);
-}
-
-.settings-error {
-  margin-bottom: 0;
-}
-
-.conversation-list {
-  display: grid;
-  gap: 12px;
-}
-
-.conversation-list-hero {
-  max-height: 320px;
-  overflow: auto;
-  padding-right: 4px;
-}
-
-.conversation-bubble {
-  padding: 14px 16px;
-  border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.03);
-}
-
-.conversation-user {
-  background: linear-gradient(160deg, rgba(28, 49, 84, 0.9), rgba(11, 17, 31, 0.72));
-  border-color: rgba(99, 175, 255, 0.22);
-}
-
-.conversation-assistant {
-  background: linear-gradient(160deg, rgba(17, 42, 38, 0.9), rgba(11, 17, 31, 0.72));
-  border-color: rgba(42, 234, 196, 0.22);
-}
-
-.conversation-bubble-head {
-  margin-bottom: 8px;
-}
-
-.conversation-bubble-head span {
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
-  font-size: 0.72rem;
-  color: rgba(237, 242, 255, 0.52);
-}
-
-.conversation-bubble p {
-  margin: 0;
-  color: rgba(237, 242, 255, 0.84);
-  line-height: 1.65;
-  white-space: pre-wrap;
-}
-
-.task-meta-wide {
-  grid-column: 1 / -1;
+  border-color: rgba(255, 179, 138, 0.48);
+  box-shadow: 0 0 0 4px rgba(255, 179, 138, 0.12);
 }
 
 .checkbox-row {
   display: flex;
-  align-items: flex-start;
   gap: 10px;
-  color: rgba(237, 242, 255, 0.78);
+  align-items: flex-start;
+  color: var(--text-soft);
 }
 
 .checkbox-row input {
   margin-top: 3px;
 }
 
-.settings-page {
-  position: relative;
-  margin: 0 auto;
-  max-width: 1360px;
+.settings-actions,
+.target-actions,
+.logs-pagination,
+.logs-toolbar-body {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
 }
 
-.settings-hero-card {
-  display: grid;
-  grid-template-columns: minmax(0, 1.5fr) minmax(300px, 0.9fr);
-  gap: 20px;
-  padding: 28px;
-  border-radius: 28px;
-  margin-bottom: 24px;
-  backdrop-filter: blur(18px);
-  background: rgba(8, 13, 24, 0.72);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.32);
-}
-
-.settings-hero-card h2 {
-  margin: 0;
-  font-size: clamp(2rem, 4vw, 3rem);
-  letter-spacing: -0.03em;
-}
-
-.settings-hero-stats {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 14px;
-}
-
-.settings-workspace {
-  display: grid;
-  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
-  gap: 20px;
-  align-items: start;
-}
-
-.settings-nav-card,
-.settings-stage-card {
-  min-height: auto;
-}
-
-.settings-nav-card {
-  position: sticky;
-  top: 24px;
-}
-
-.settings-nav-list {
-  display: grid;
-  gap: 12px;
-}
-
-.settings-nav-item {
-  width: 100%;
-  text-align: left;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 22px;
-  padding: 18px;
-  color: rgba(237, 242, 255, 0.84);
-  background: linear-gradient(160deg, rgba(18, 31, 54, 0.88), rgba(11, 17, 31, 0.74));
-  font: inherit;
+.settings-button,
+.secondary-button,
+.ghost-button,
+.icon-button {
+  border: 0;
   cursor: pointer;
-  transition:
-    transform 180ms ease,
-    border-color 180ms ease,
-    background 180ms ease,
-    box-shadow 180ms ease;
-}
-
-.settings-nav-item:hover {
-  transform: translateY(-1px);
-  border-color: rgba(42, 234, 196, 0.24);
-}
-
-.settings-nav-item span {
-  display: block;
-  margin-bottom: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
-  font-size: 0.72rem;
-  color: rgba(237, 242, 255, 0.46);
-}
-
-.settings-nav-item strong {
-  display: block;
-  font-size: 1.08rem;
-  letter-spacing: -0.02em;
-}
-
-.settings-nav-item p {
-  margin: 8px 0 0;
-  color: rgba(237, 242, 255, 0.68);
-  line-height: 1.6;
-}
-
-.settings-nav-item-active {
-  border-color: rgba(42, 234, 196, 0.32);
-  background:
-    linear-gradient(160deg, rgba(16, 47, 51, 0.92), rgba(11, 17, 31, 0.82)),
-    linear-gradient(135deg, rgba(42, 234, 196, 0.18), rgba(255, 192, 98, 0.12));
-  box-shadow: inset 0 1px 0 rgba(92, 251, 236, 0.22), 0 18px 60px rgba(0, 0, 0, 0.32);
-}
-
-.settings-nav-item-active span {
-  color: rgba(184, 255, 224, 0.78);
-}
-
-.settings-stage {
-  display: grid;
-  gap: 18px;
-}
-
-.settings-stage-copy {
-  margin: 0;
-  color: rgba(237, 242, 255, 0.72);
-  line-height: 1.7;
-}
-
-.settings-grid-page {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 20px;
-}
-
-.settings-grid-single {
-  grid-template-columns: minmax(0, 1fr);
-}
-
-.settings-panel {
-  min-height: 100%;
-}
-
-.panel-wide {
-  grid-column: 1 / -1;
-}
-
-.settings-modal-backdrop {
-  position: fixed;
-  inset: 0;
-  z-index: 40;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 24px;
-  background: rgba(2, 6, 15, 0.72);
-  backdrop-filter: blur(16px);
-}
-
-.settings-modal-card {
-  width: min(860px, 100%);
-  max-height: min(92vh, 920px);
-  overflow: auto;
-  padding: 24px;
-  border-radius: 28px;
-  backdrop-filter: blur(18px);
-  background: rgba(8, 13, 24, 0.92);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.4);
-}
-
-.settings-login-grid {
-  display: grid;
-  grid-template-columns: minmax(240px, 280px) minmax(0, 1fr);
-  gap: 18px;
-}
-
-.settings-login-confirm {
-  display: grid;
-  gap: 18px;
-}
-
-.qr-card {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 280px;
-  padding: 18px;
-  border-radius: 22px;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.07);
-}
-
-.qr-image {
-  width: min(240px, 100%);
-  height: auto;
   border-radius: 16px;
-  background: white;
-  padding: 12px;
+  padding: 11px 16px;
+  font-weight: 800;
+  transition: transform 160ms ease, opacity 160ms ease;
 }
 
-.qr-empty {
-  width: 100%;
-  text-align: center;
+.settings-button:hover,
+.secondary-button:hover,
+.ghost-button:hover,
+.icon-button:hover {
+  transform: translateY(-1px);
 }
 
-.login-copy {
-  display: grid;
-  gap: 14px;
+.settings-button:disabled,
+.secondary-button:disabled,
+.ghost-button:disabled,
+.icon-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+  transform: none;
+}
+
+.settings-button {
+  color: #7a472d;
+  background: linear-gradient(135deg, #ffd3be 0%, #ffe6a2 100%);
+}
+
+.secondary-button,
+.ghost-button,
+.icon-button {
+  color: var(--text-main);
+  background: rgba(255, 255, 255, 0.88);
+  border: 1px solid var(--line);
+}
+
+.ghost-danger {
+  color: #b15561;
 }
 
 .account-grid,
 .target-list {
   display: grid;
-  gap: 14px;
+  gap: 12px;
 }
 
 .account-card,
 .target-card {
-  padding: 18px;
-  border-radius: 22px;
-  background: linear-gradient(160deg, rgba(18, 31, 54, 0.92), rgba(11, 17, 31, 0.76));
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: grid;
+  gap: 12px;
 }
 
-.account-card-head {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 14px;
-  margin-bottom: 14px;
-}
-
-.account-card-head h4 {
+.account-card-head h4,
+.account-card-head p {
   margin: 0;
-  font-size: 1.15rem;
 }
 
 .account-card-head p {
-  margin: 6px 0 0;
-  color: rgba(237, 242, 255, 0.6);
+  color: var(--text-faint);
 }
 
-.target-editor {
+.focus-grid {
   display: grid;
-  grid-template-columns: minmax(280px, 0.9fr) minmax(0, 1.1fr);
-  gap: 18px;
-}
-
-.target-card {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 14px;
-}
-
-.target-actions {
-  display: flex;
-  align-items: center;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 10px;
-  flex-wrap: wrap;
 }
 
-.logs-page {
-  position: relative;
-  margin: 0 auto;
-  max-width: 1360px;
+.task-meta {
   display: grid;
-  gap: 20px;
+  gap: 4px;
+  padding: 12px 14px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(181, 135, 111, 0.1);
 }
 
-.logs-hero-card {
-  margin-bottom: 0;
+.task-meta-wide {
+  grid-column: 1 / -1;
 }
 
-.logs-toolbar {
+.task-meta span {
+  color: var(--text-faint);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.settings-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 20px;
+  background: rgba(131, 93, 74, 0.18);
+  backdrop-filter: blur(8px);
+}
+
+.settings-modal-card {
+  width: min(760px, 100%);
+  max-height: min(88vh, 920px);
+  padding: 20px;
+  overflow: auto;
+}
+
+.settings-login-grid,
+.settings-login-confirm {
   display: grid;
   gap: 16px;
 }
 
-.logs-size-field {
-  min-width: 140px;
+.settings-login-grid {
+  grid-template-columns: minmax(220px, 260px) minmax(0, 1fr);
 }
 
-.logs-list {
+.qr-card {
   display: grid;
-  gap: 14px;
+  place-items: center;
+  padding: 16px;
+  border-radius: 24px;
+  border: 1px dashed rgba(181, 135, 111, 0.3);
+  background: rgba(255, 255, 255, 0.7);
 }
 
-.logs-stream {
+.qr-image {
+  width: min(100%, 220px);
+  aspect-ratio: 1;
+  object-fit: contain;
+  border-radius: 18px;
+  background: white;
+  padding: 10px;
+}
+
+.login-copy {
   display: grid;
-  gap: 16px;
+  gap: 12px;
 }
 
-.logs-stream-list {
+.helper-card .section-card-body {
+  padding: 16px;
+}
+
+.helper-points {
   display: grid;
-  gap: 0;
+  gap: 10px;
 }
 
-.log-row {
+.logs-layout {
+  grid-template-rows: auto minmax(0, 1fr);
+  min-height: 0;
+}
+
+.logs-toolbar-body {
+  justify-content: space-between;
+}
+
+.logs-stream-card .section-card-body {
+  overflow: auto;
+}
+
+.log-line {
   display: grid;
   gap: 8px;
-  padding: 14px 0;
-  border-top: 1px solid rgba(255, 255, 255, 0.07);
 }
 
-.log-row:first-child {
-  border-top: 0;
-}
-
-.log-row-primary {
-  display: flex;
-  align-items: center;
-  gap: 12px;
+.log-line-head {
   flex-wrap: wrap;
+  color: var(--text-faint);
 }
 
-.log-source {
-  color: rgba(237, 242, 255, 0.76);
-  word-break: break-all;
-}
-
-.log-row-message {
-  margin: 0;
-  white-space: pre-wrap;
-  word-break: break-word;
-  color: rgba(237, 242, 255, 0.88);
-  line-height: 1.55;
-}
-
-.log-row-raw {
+.log-line-raw {
   display: block;
-  color: rgba(237, 242, 255, 0.46);
-  font-size: 0.84rem;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.7);
+  color: #927668;
   white-space: pre-wrap;
   word-break: break-word;
-  line-height: 1.5;
 }
 
-.logs-error-banner {
-  margin: 0 auto;
-  max-width: 1360px;
+.log-level {
+  padding-inline: 10px;
 }
 
-.insight-card h3 {
-  margin: 8px 0 10px;
-  font-size: 1.4rem;
+.log-level-debug {
+  background: rgba(139, 200, 255, 0.18);
+  color: #4b78a7;
 }
 
-.insight-card p {
-  margin: 0 0 14px;
-  line-height: 1.65;
-  color: rgba(237, 242, 255, 0.76);
+.log-level-info {
+  background: rgba(137, 219, 198, 0.22);
+  color: #2d7f6c;
 }
 
-.insight-card span {
-  color: rgba(237, 242, 255, 0.48);
-  font-size: 0.85rem;
+.log-level-warn {
+  background: rgba(255, 217, 142, 0.26);
+  color: #9b7034;
 }
 
-@media (max-width: 1100px) {
-  .hero,
-  .content-grid,
-  .settings-workspace,
-  .settings-grid-page,
-  .settings-hero-card,
+.log-level-error,
+.log-level-fatal {
+  background: rgba(244, 165, 185, 0.24);
+  color: #ab5160;
+}
+
+@media (max-width: 1180px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+    height: auto;
+    min-height: 100dvh;
+    overflow: auto;
+  }
+
+  html,
+  body {
+    overflow: auto;
+  }
+
+  .app-sidebar {
+    order: -1;
+  }
+
+  .app-main {
+    min-height: 0;
+    overflow: visible;
+  }
+
+  .page-shell {
+    height: auto;
+    overflow: visible;
+  }
+
+  .dashboard-layout,
+  .settings-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard-stage {
+    grid-template-rows: auto auto;
+  }
+
+  .settings-content-single,
   .target-editor,
+  .page-hero,
   .settings-login-grid {
     grid-template-columns: 1fr;
   }
-
-  .settings-nav-card {
-    position: static;
-  }
-
-  .metrics-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
 }
 
-@media (max-width: 720px) {
-  .app-shell {
-    padding: 22px 16px 40px;
+@media (max-width: 760px) {
+  .app-shell,
+  .page-shell {
+    padding: 14px;
   }
 
-  .hero-copy,
-  .hero-panel,
-  .panel,
-  .timeline-card,
-  .insight-card {
-    padding: 20px;
-    border-radius: 22px;
+  .app-sidebar,
+  .app-main,
+  .page-hero-copy,
+  .hero-metrics,
+  .section-card,
+  .panel {
+    border-radius: 24px;
   }
 
-  .metrics-grid {
-    grid-template-columns: 1fr;
+  .brand-card h1,
+  .page-hero h2,
+  .section-title {
+    font-size: 1.8rem;
   }
 
-  .panel-head,
-  .task-card-head,
-  .focus-card-head,
-  .timeline-head,
-  .task-card-foot,
-  .topbar,
-  .account-card-head,
-  .target-card {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
+  .hero-metrics,
+  .detail-grid,
   .focus-grid {
     grid-template-columns: 1fr;
   }
 
-  .topbar-nav {
-    width: 100%;
-    justify-content: flex-start;
+  .pill-tabs {
+    padding-bottom: 6px;
+  }
+
+  .pill-tab {
+    min-width: 146px;
   }
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4,27 +4,32 @@
   color-scheme: light;
   font-family: "Nunito", "Avenir Next", "Segoe UI", sans-serif;
   background:
-    radial-gradient(circle at top left, rgba(255, 187, 155, 0.44), transparent 28%),
-    radial-gradient(circle at top right, rgba(136, 222, 201, 0.36), transparent 24%),
-    radial-gradient(circle at bottom right, rgba(255, 224, 153, 0.38), transparent 24%),
-    linear-gradient(180deg, #fffaf4 0%, #fff6ef 100%);
-  color: #5a4034;
-  --bg: #fffaf4;
-  --panel: rgba(255, 255, 255, 0.74);
-  --panel-strong: rgba(255, 255, 255, 0.92);
-  --line: rgba(181, 135, 111, 0.16);
-  --line-strong: rgba(181, 135, 111, 0.28);
-  --text-main: #5a4034;
-  --text-soft: #7f6659;
-  --text-faint: #a08475;
-  --peach: #ffb38a;
-  --mint: #89dbc6;
-  --sky: #8bc8ff;
-  --butter: #ffd98e;
-  --rose: #f4a5b9;
-  --danger: #d45b69;
-  --shadow: 0 24px 60px rgba(183, 132, 96, 0.14);
-  --shadow-soft: 0 12px 26px rgba(183, 132, 96, 0.08);
+    radial-gradient(circle at top left, rgba(173, 211, 255, 0.5), transparent 30%),
+    radial-gradient(circle at top right, rgba(205, 193, 255, 0.42), transparent 28%),
+    radial-gradient(circle at bottom left, rgba(189, 245, 223, 0.34), transparent 24%),
+    linear-gradient(180deg, #eef5ff 0%, #f7faff 45%, #fbfdff 100%);
+  color: #20345f;
+  --bg: #f4f8ff;
+  --panel: rgba(255, 255, 255, 0.82);
+  --panel-strong: rgba(255, 255, 255, 0.96);
+  --line: rgba(151, 179, 235, 0.2);
+  --line-strong: rgba(131, 161, 223, 0.34);
+  --text-main: #20345f;
+  --text-soft: #5f7297;
+  --text-faint: #8ea0bf;
+  --blue: #2e7dff;
+  --blue-soft: #ecf4ff;
+  --purple: #8770ff;
+  --mint: #4bc79a;
+  --mint-soft: #ebfff7;
+  --sky: #7ab8ff;
+  --butter: #ffe18f;
+  --rose: #ff8f99;
+  --danger: #ef5a64;
+  --danger-soft: #fff1f3;
+  --neutral-soft: #f3f6ff;
+  --shadow: 0 24px 54px rgba(83, 122, 188, 0.14);
+  --shadow-soft: 0 12px 30px rgba(120, 149, 213, 0.1);
 }
 
 * {
@@ -67,10 +72,10 @@ code {
 .app-shell {
   position: relative;
   display: grid;
-  grid-template-columns: 288px minmax(0, 1fr);
-  gap: 18px;
+  grid-template-columns: 220px minmax(0, 1fr);
+  gap: 16px;
   height: 100dvh;
-  padding: 18px;
+  padding: 14px;
   overflow: hidden;
 }
 
@@ -84,10 +89,10 @@ code {
 
 .app-glow-left {
   top: -120px;
-  left: -80px;
+  left: -60px;
   width: 260px;
   height: 260px;
-  background: rgba(255, 179, 138, 0.58);
+  background: rgba(120, 182, 255, 0.32);
 }
 
 .app-glow-right {
@@ -95,7 +100,7 @@ code {
   bottom: -100px;
   width: 300px;
   height: 300px;
-  background: rgba(137, 219, 198, 0.46);
+  background: rgba(139, 112, 255, 0.18);
 }
 
 .app-sidebar,
@@ -110,12 +115,14 @@ code {
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 18px;
   min-height: 0;
-  padding: 18px;
+  padding: 18px 16px;
   border: 1px solid var(--line);
-  border-radius: 30px;
-  background: rgba(255, 255, 255, 0.72);
+  border-radius: 28px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(243, 248, 255, 0.96)),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.8));
   box-shadow: var(--shadow);
   backdrop-filter: blur(18px);
 }
@@ -196,8 +203,8 @@ code {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 14px;
-  border-radius: 22px;
+  padding: 16px 14px;
+  border-radius: 20px;
   border: 1px solid transparent;
   color: var(--text-soft);
   transition:
@@ -208,15 +215,17 @@ code {
 
 .sidebar-link:hover {
   transform: translateY(-1px);
-  background: rgba(255, 255, 255, 0.6);
-  border-color: rgba(255, 179, 138, 0.22);
+  background: rgba(255, 255, 255, 0.72);
+  border-color: rgba(115, 159, 255, 0.22);
 }
 
 .sidebar-link-active {
-  background: linear-gradient(135deg, rgba(255, 226, 207, 0.95), rgba(255, 245, 233, 0.98));
-  border-color: rgba(255, 179, 138, 0.28);
+  background: linear-gradient(135deg, rgba(246, 251, 255, 0.98), rgba(232, 241, 255, 0.98));
+  border-color: rgba(82, 136, 255, 0.24);
   color: var(--text-main);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.92),
+    0 10px 24px rgba(125, 165, 233, 0.1);
 }
 
 .sidebar-link-icon {
@@ -226,22 +235,17 @@ code {
   width: 42px;
   height: 42px;
   border-radius: 16px;
-  background: rgba(255, 255, 255, 0.75);
-  color: #c67856;
-  border: 1px solid rgba(255, 179, 138, 0.22);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--blue);
+  border: 1px solid rgba(114, 159, 255, 0.18);
 }
 
 .sidebar-link-copy {
-  display: grid;
-  gap: 2px;
+  display: block;
 }
 
 .sidebar-link-copy strong {
-  font-size: 1rem;
-}
-
-.sidebar-link-copy small {
-  color: var(--text-faint);
+  font-size: 1.04rem;
 }
 
 .sidebar-stats {
@@ -289,11 +293,237 @@ code {
   position: relative;
   min-height: 0;
   overflow: hidden;
-  border-radius: 34px;
+  border-radius: 32px;
   border: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.54);
+  background: rgba(255, 255, 255, 0.72);
   box-shadow: var(--shadow);
   backdrop-filter: blur(18px);
+}
+
+.sidebar-brand {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 8px 8px;
+}
+
+.sidebar-brand-mark {
+  flex: 0 0 auto;
+}
+
+.sidebar-logo-shell {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 56px;
+  height: 56px;
+  border-radius: 18px;
+  background: linear-gradient(180deg, #ffffff 0%, #ecf4ff 100%);
+  border: 1px solid rgba(116, 156, 247, 0.22);
+  box-shadow: 0 10px 22px rgba(118, 156, 226, 0.18);
+}
+
+.sidebar-logo-face {
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 14px;
+  color: white;
+  background: linear-gradient(180deg, #6fb8ff 0%, #3d7fff 100%);
+}
+
+.sidebar-logo-dot {
+  position: absolute;
+  display: block;
+  border-radius: 999px;
+  background: #ffd56e;
+  box-shadow: 0 0 0 4px rgba(255, 213, 110, 0.18);
+}
+
+.sidebar-logo-dot-top {
+  top: 7px;
+  right: 8px;
+  width: 8px;
+  height: 8px;
+}
+
+.sidebar-logo-dot-bottom {
+  bottom: 8px;
+  left: 8px;
+  width: 6px;
+  height: 6px;
+  background: #9edac4;
+  box-shadow: 0 0 0 4px rgba(158, 218, 196, 0.18);
+}
+
+.sidebar-brand-copy {
+  display: grid;
+  gap: 3px;
+}
+
+.sidebar-brand-copy strong {
+  font-size: 1.85rem;
+  line-height: 1;
+  letter-spacing: -0.04em;
+  color: #1e62e8;
+  font-family: "Baloo 2", "Nunito", sans-serif;
+}
+
+.sidebar-brand-copy small {
+  color: var(--text-faint);
+  font-weight: 700;
+}
+
+.sidebar-mascot-card {
+  position: relative;
+  margin-top: auto;
+  min-height: 230px;
+  overflow: hidden;
+  border-radius: 24px;
+  border: 1px solid rgba(134, 171, 242, 0.22);
+  background:
+    radial-gradient(circle at left bottom, rgba(137, 219, 198, 0.26), transparent 24%),
+    radial-gradient(circle at right top, rgba(172, 154, 255, 0.2), transparent 24%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(236, 244, 255, 0.95));
+}
+
+.sidebar-mascot-stars span {
+  position: absolute;
+  display: block;
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #ffd98f;
+  opacity: 0.9;
+}
+
+.sidebar-mascot-stars span:nth-child(1) {
+  top: 30px;
+  left: 22px;
+}
+
+.sidebar-mascot-stars span:nth-child(2) {
+  top: 56px;
+  right: 36px;
+  width: 8px;
+  height: 8px;
+}
+
+.sidebar-mascot-stars span:nth-child(3) {
+  top: 110px;
+  left: 48px;
+  width: 6px;
+  height: 6px;
+}
+
+.sidebar-mascot-floor {
+  position: absolute;
+  left: 50%;
+  bottom: 30px;
+  width: 148px;
+  height: 28px;
+  border-radius: 999px;
+  transform: translateX(-50%);
+  background: rgba(121, 164, 255, 0.12);
+}
+
+.sidebar-mascot-bot {
+  position: absolute;
+  left: 50%;
+  bottom: 44px;
+  transform: translateX(-50%);
+}
+
+.sidebar-mascot-antenna {
+  position: absolute;
+  top: -18px;
+  left: 50%;
+  width: 2px;
+  height: 18px;
+  transform: translateX(-50%);
+  background: #7ea8f1;
+}
+
+.sidebar-mascot-antenna::after {
+  content: "";
+  position: absolute;
+  top: -8px;
+  left: 50%;
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  transform: translateX(-50%);
+  background: #ffcf68;
+}
+
+.sidebar-mascot-head {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  width: 92px;
+  height: 68px;
+  border-radius: 24px;
+  background: linear-gradient(180deg, #ffffff 0%, #edf4ff 100%);
+  border: 1px solid rgba(128, 171, 255, 0.28);
+  box-shadow: 0 16px 28px rgba(124, 158, 226, 0.18);
+}
+
+.sidebar-mascot-eye {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, #66b2ff 0%, #3d7fff 100%);
+  box-shadow: 0 0 0 4px rgba(102, 178, 255, 0.12);
+}
+
+.sidebar-mascot-body {
+  width: 62px;
+  height: 74px;
+  margin: 10px auto 0;
+  border-radius: 24px 24px 18px 18px;
+  background: linear-gradient(180deg, #ffffff 0%, #eef4ff 100%);
+  border: 1px solid rgba(128, 171, 255, 0.24);
+  box-shadow: 0 16px 28px rgba(124, 158, 226, 0.12);
+}
+
+.sidebar-user-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: 20px;
+  border: 1px solid rgba(136, 167, 235, 0.22);
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--text-soft);
+}
+
+.sidebar-user-avatar {
+  display: grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  color: white;
+  font-weight: 800;
+  background: linear-gradient(180deg, #61a8ff 0%, #2f75ff 100%);
+}
+
+.sidebar-user-copy {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+
+.sidebar-user-copy strong {
+  color: var(--text-main);
+}
+
+.sidebar-user-copy small {
+  color: var(--text-faint);
+  overflow-wrap: anywhere;
 }
 
 .page-shell {
@@ -304,6 +534,7 @@ code {
   padding: 18px;
   min-height: 0;
   overflow: hidden;
+  overflow-x: hidden;
 }
 
 .page-hero {
@@ -400,6 +631,163 @@ code {
   color: #7c6b5d;
 }
 
+.dashboard-page {
+  gap: 18px;
+}
+
+.dashboard-shell {
+  overflow-y: auto;
+}
+
+.dashboard-header {
+  display: grid;
+  grid-template-columns: minmax(0, 0.62fr) minmax(0, 1.38fr);
+  gap: 18px;
+  align-items: start;
+}
+
+.dashboard-header-title {
+  display: grid;
+  gap: 12px;
+  padding: 18px 10px 0 6px;
+}
+
+.dashboard-title-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.dashboard-title-row h2 {
+  margin: 0;
+  font-size: clamp(2rem, 2.6vw, 2.8rem);
+  color: #172f63;
+  font-family: "Baloo 2", "Nunito", sans-serif;
+  letter-spacing: -0.04em;
+}
+
+.dashboard-header-title p {
+  margin: 0;
+  max-width: 42ch;
+  line-height: 1.7;
+  color: var(--text-soft);
+}
+
+.service-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(94, 210, 148, 0.24);
+  background: linear-gradient(180deg, #f3fff9 0%, #ebfff5 100%);
+  color: #21a35e;
+  font-weight: 800;
+}
+
+.service-pill::before {
+  content: "";
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.service-pill-danger {
+  border-color: rgba(239, 90, 100, 0.24);
+  background: linear-gradient(180deg, #fff6f7 0%, #fff1f3 100%);
+  color: #d84b55;
+}
+
+.dashboard-header-stats {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.dashboard-stat-card {
+  display: grid;
+  gap: 8px;
+  flex: 0 0 110px;
+  min-width: 110px;
+  padding: 16px 18px;
+  border-radius: 22px;
+  border: 1px solid rgba(151, 179, 235, 0.18);
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: var(--shadow-soft);
+}
+
+.dashboard-stat-card span {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-soft);
+  font-weight: 700;
+}
+
+.dashboard-stat-card strong {
+  font-size: 2rem;
+  line-height: 1;
+  letter-spacing: -0.04em;
+  color: #182f60;
+  font-family: "Baloo 2", "Nunito", sans-serif;
+}
+
+.dashboard-stat-card small {
+  color: var(--text-faint);
+}
+
+.dashboard-stat-card-neutral {
+  box-shadow: inset 0 1px 0 rgba(122, 184, 255, 0.22);
+}
+
+.dashboard-stat-card-running {
+  box-shadow: inset 0 1px 0 rgba(84, 151, 255, 0.26);
+}
+
+.dashboard-stat-card-completed {
+  box-shadow: inset 0 1px 0 rgba(82, 199, 149, 0.26);
+}
+
+.dashboard-stat-card-failed {
+  box-shadow: inset 0 1px 0 rgba(239, 90, 100, 0.22);
+}
+
+.dashboard-stat-card-canceled {
+  box-shadow: inset 0 1px 0 rgba(139, 112, 255, 0.16);
+}
+
+.dashboard-stat-card-refresh strong {
+  font-size: 1.3rem;
+}
+
+.dashboard-stat-card-refresh {
+  min-width: 136px;
+}
+
+.dashboard-reference-grid {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(280px, 300px) minmax(0, 1fr) minmax(300px, 320px);
+  gap: 16px;
+  align-items: start;
+}
+
+.dashboard-left-column,
+.dashboard-center-column,
+.dashboard-right-column {
+  min-height: 0;
+}
+
+.dashboard-right-column {
+  display: grid;
+  grid-template-rows: minmax(220px, 0.96fr) minmax(170px, 0.66fr) minmax(170px, 0.62fr) minmax(180px, 0.72fr);
+  gap: 16px;
+}
+
 .dashboard-layout,
 .settings-layout,
 .logs-layout {
@@ -469,6 +857,25 @@ code {
   gap: 14px;
 }
 
+.card-inline-icon,
+.section-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #5a88ff;
+  font-weight: 800;
+  font-size: 0.92rem;
+}
+
+.card-inline-icon {
+  width: 34px;
+  height: 34px;
+  justify-content: center;
+  border-radius: 12px;
+  border: 1px solid rgba(125, 165, 233, 0.18);
+  background: rgba(246, 250, 255, 0.95);
+}
+
 .task-list-stack,
 .timeline-stack,
 .logs-stream-list,
@@ -489,15 +896,89 @@ code {
   padding-right: 2px;
 }
 
+.dashboard-rail-card,
+.dashboard-main-card,
+.dashboard-side-card {
+  background: rgba(255, 255, 255, 0.94);
+  border: 1px solid rgba(151, 179, 235, 0.18);
+  box-shadow: var(--shadow-soft);
+}
+
+.dashboard-rail-card .section-title,
+.dashboard-side-card .section-title,
+.dashboard-main-card .section-title {
+  font-size: 1.45rem;
+}
+
+.dashboard-main-card .section-card-body {
+  gap: 18px;
+}
+
+.dashboard-side-card .section-card-body {
+  overflow: auto;
+  min-height: 0;
+  padding-right: 2px;
+}
+
+.task-list-shell {
+  display: grid;
+  gap: 14px;
+  min-height: 0;
+}
+
+.task-list-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.task-list-summary-card {
+  display: grid;
+  gap: 4px;
+  padding: 12px 8px;
+  border-radius: 18px;
+  border: 1px solid rgba(151, 179, 235, 0.18);
+  background: rgba(247, 250, 255, 0.98);
+  text-align: center;
+}
+
+.task-list-summary-card strong {
+  font-size: 1.55rem;
+  line-height: 1;
+  color: #18315f;
+  font-family: "Baloo 2", "Nunito", sans-serif;
+}
+
+.task-list-summary-card span {
+  color: var(--text-faint);
+  font-weight: 700;
+}
+
+.task-list-summary-running strong {
+  color: var(--blue);
+}
+
+.task-list-summary-completed strong {
+  color: var(--mint);
+}
+
+.task-list-summary-failed strong {
+  color: var(--danger);
+}
+
+.task-list-summary-canceled strong {
+  color: var(--purple);
+}
+
 .task-teaser {
   text-align: left;
   display: grid;
-  gap: 12px;
+  gap: 10px;
   width: 100%;
-  padding: 16px;
-  border-radius: 22px;
-  border: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.76);
+  padding: 14px 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(151, 179, 235, 0.16);
+  background: rgba(255, 255, 255, 0.82);
   color: inherit;
   cursor: pointer;
   transition:
@@ -508,13 +989,15 @@ code {
 
 .task-teaser:hover {
   transform: translateY(-1px);
-  border-color: rgba(255, 179, 138, 0.34);
+  border-color: rgba(95, 146, 255, 0.28);
 }
 
 .task-teaser-active {
-  border-color: rgba(255, 179, 138, 0.46);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.88);
-  background: linear-gradient(180deg, rgba(255, 248, 244, 0.96), rgba(255, 241, 234, 0.88));
+  border-color: rgba(53, 120, 255, 0.36);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.92),
+    0 14px 28px rgba(109, 149, 224, 0.12);
+  background: linear-gradient(180deg, rgba(246, 250, 255, 1), rgba(234, 242, 255, 0.96));
 }
 
 .task-teaser-head,
@@ -533,7 +1016,8 @@ code {
 
 .task-teaser-copy {
   display: grid;
-  gap: 6px;
+  gap: 4px;
+  min-width: 0;
 }
 
 .task-teaser-copy strong,
@@ -551,12 +1035,14 @@ code {
 .task-input,
 .task-meta p,
 .soft-panel p,
+.task-detail-panel p,
 .helper-points p,
 .empty-state p,
 .log-line-message {
   margin: 0;
   color: var(--text-soft);
   line-height: 1.65;
+  overflow-wrap: anywhere;
 }
 
 .task-teaser-meta,
@@ -579,6 +1065,21 @@ code {
   gap: 6px;
 }
 
+.task-teaser-head {
+  align-items: center;
+}
+
+.task-teaser-side {
+  display: grid;
+  justify-items: end;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+
+.task-teaser-summary {
+  font-size: 0.94rem;
+}
+
 .status-badge,
 .soft-chip,
 .log-level {
@@ -594,51 +1095,58 @@ code {
 }
 
 .status-accepted {
-  color: #8d653c;
-  background: rgba(255, 217, 142, 0.28);
-  border-color: rgba(255, 217, 142, 0.48);
+  color: #6f61d9;
+  background: rgba(135, 112, 255, 0.12);
+  border-color: rgba(135, 112, 255, 0.22);
 }
 
 .status-running {
-  color: #1f8470;
-  background: rgba(137, 219, 198, 0.24);
-  border-color: rgba(137, 219, 198, 0.48);
+  color: var(--blue);
+  background: rgba(46, 125, 255, 0.1);
+  border-color: rgba(46, 125, 255, 0.18);
 }
 
 .status-completed {
-  color: #5f7b26;
-  background: rgba(205, 235, 151, 0.32);
-  border-color: rgba(205, 235, 151, 0.5);
+  color: #1ca36d;
+  background: rgba(75, 199, 154, 0.12);
+  border-color: rgba(75, 199, 154, 0.2);
 }
 
 .status-failed,
 .status-canceled {
-  color: #b15561;
-  background: rgba(244, 165, 185, 0.24);
-  border-color: rgba(244, 165, 185, 0.48);
+  color: var(--danger);
+  background: rgba(239, 90, 100, 0.1);
+  border-color: rgba(239, 90, 100, 0.18);
+}
+
+.status-canceled {
+  color: #7263d8;
+  background: rgba(135, 112, 255, 0.1);
+  border-color: rgba(135, 112, 255, 0.18);
 }
 
 .soft-chip {
-  color: #bb6d51;
-  background: rgba(255, 243, 237, 0.92);
-  border-color: rgba(255, 179, 138, 0.3);
+  color: var(--blue);
+  background: rgba(239, 246, 255, 0.96);
+  border-color: rgba(116, 156, 247, 0.2);
 }
 
 .soft-chip-peach {
-  background: rgba(255, 239, 229, 0.96);
+  background: rgba(246, 250, 255, 0.96);
 }
 
 .pill-tabs {
   display: flex;
   gap: 10px;
-  overflow: auto;
-  padding-bottom: 2px;
+  flex-wrap: wrap;
+  overflow: visible;
+  padding-bottom: 0;
 }
 
 .pill-tab {
   display: grid;
   gap: 2px;
-  min-width: 120px;
+  min-width: 132px;
   padding: 12px 14px;
   border-radius: 20px;
   border: 1px solid var(--line);
@@ -646,7 +1154,7 @@ code {
   color: inherit;
   text-align: left;
   cursor: pointer;
-  flex: 0 0 auto;
+  flex: 1 1 168px;
 }
 
 .pill-tab strong {
@@ -661,6 +1169,28 @@ code {
 .pill-tab-active {
   border-color: rgba(255, 179, 138, 0.36);
   background: linear-gradient(180deg, rgba(255, 248, 242, 1), rgba(255, 239, 229, 0.94));
+}
+
+.settings-pill-tabs {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.settings-pill-tabs .pill-tab {
+  min-width: 0;
+  min-height: 92px;
+  flex: none;
+  align-content: start;
+  padding: 14px 16px;
+}
+
+.settings-pill-tabs .pill-tab strong {
+  line-height: 1.2;
+}
+
+.settings-pill-tabs .pill-tab span {
+  line-height: 1.45;
 }
 
 .detail-grid {
@@ -784,6 +1314,406 @@ code {
   color: #aa5360;
 }
 
+.task-detail-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 180px;
+  gap: 16px;
+  align-items: center;
+}
+
+.task-detail-meta-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.task-detail-meta {
+  display: grid;
+  gap: 4px;
+  padding: 12px 14px;
+  border-radius: 18px;
+  border: 1px solid rgba(151, 179, 235, 0.18);
+  background: rgba(248, 251, 255, 0.98);
+}
+
+.task-detail-meta span {
+  color: var(--text-faint);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.task-detail-meta p {
+  margin: 0;
+  color: var(--text-main);
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.task-detail-mascot {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-height: 176px;
+}
+
+.task-detail-mascot-ring {
+  position: absolute;
+  width: 148px;
+  height: 148px;
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(154, 194, 255, 0.28), rgba(166, 137, 255, 0.06));
+  filter: blur(1px);
+}
+
+.task-detail-mascot-core {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  place-items: center;
+  width: 78px;
+  height: 78px;
+  border-radius: 28px;
+  color: white;
+  background: linear-gradient(180deg, #73b6ff 0%, #4e86ff 100%);
+  box-shadow: 0 18px 36px rgba(104, 146, 237, 0.25);
+}
+
+.task-detail-star {
+  position: absolute;
+  z-index: 2;
+  color: #ffcf68;
+}
+
+.task-detail-star-a {
+  top: 28px;
+  right: 28px;
+}
+
+.task-detail-star-b {
+  bottom: 30px;
+  left: 28px;
+}
+
+.task-progress-card {
+  display: grid;
+  gap: 18px;
+  padding: 18px 20px;
+  border-radius: 22px;
+  border: 1px solid rgba(151, 179, 235, 0.18);
+  background: rgba(248, 251, 255, 0.98);
+}
+
+.task-progress-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.task-progress-head strong,
+.task-detail-panel-head strong {
+  color: var(--text-main);
+}
+
+.task-progress-head p {
+  margin: 6px 0 0;
+  color: var(--text-soft);
+}
+
+.task-progress-value {
+  display: grid;
+  justify-items: end;
+  gap: 4px;
+}
+
+.task-progress-value span {
+  color: var(--text-faint);
+  font-size: 0.88rem;
+}
+
+.task-progress-value strong {
+  font-family: "Baloo 2", "Nunito", sans-serif;
+  font-size: 1.5rem;
+  color: var(--blue);
+}
+
+.task-progress-bar {
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(196, 214, 255, 0.42);
+  overflow: hidden;
+}
+
+.task-progress-bar span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #5d9bff 0%, #2f75ff 100%);
+}
+
+.task-progress-steps {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.task-progress-step {
+  display: grid;
+  justify-items: center;
+  gap: 10px;
+  text-align: center;
+}
+
+.task-progress-node {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 999px;
+  border: 1px solid rgba(151, 179, 235, 0.28);
+  color: var(--text-faint);
+  background: white;
+  font-weight: 800;
+}
+
+.task-progress-node-done {
+  color: white;
+  border-color: rgba(46, 125, 255, 0.2);
+  background: linear-gradient(180deg, #63a8ff 0%, #2f75ff 100%);
+}
+
+.task-progress-node-active {
+  box-shadow: 0 0 0 5px rgba(93, 155, 255, 0.12);
+}
+
+.task-progress-copy {
+  display: grid;
+  gap: 4px;
+}
+
+.task-progress-copy strong {
+  font-size: 0.94rem;
+}
+
+.task-progress-copy span {
+  color: var(--text-faint);
+  font-size: 0.84rem;
+  line-height: 1.45;
+}
+
+.task-detail-bottom-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.task-detail-panel {
+  display: grid;
+  gap: 10px;
+  padding: 18px;
+  border-radius: 20px;
+  border: 1px solid rgba(151, 179, 235, 0.18);
+  background: rgba(255, 255, 255, 0.96);
+}
+
+.task-detail-panel-wide {
+  grid-column: 1 / -1;
+}
+
+.task-detail-panel-muted {
+  background: linear-gradient(180deg, rgba(243, 248, 255, 0.98), rgba(238, 244, 255, 0.96));
+}
+
+.task-detail-panel-head {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--blue);
+}
+
+.timeline-list,
+.recent-conversation-list,
+.record-facts {
+  display: grid;
+  gap: 12px;
+}
+
+.timeline-row {
+  display: grid;
+  grid-template-columns: 16px 88px minmax(88px, auto) minmax(0, 1fr);
+  gap: 10px;
+  align-items: start;
+}
+
+.timeline-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  margin-top: 6px;
+}
+
+.timeline-dot-0 {
+  background: #25b7ff;
+}
+
+.timeline-dot-1 {
+  background: #38c78d;
+}
+
+.timeline-dot-2 {
+  background: #ffb64d;
+}
+
+.timeline-dot-3 {
+  background: #8f6cff;
+}
+
+.timeline-dot-4 {
+  background: #4f84ff;
+}
+
+.timeline-time {
+  color: var(--text-faint);
+  font-size: 0.86rem;
+}
+
+.timeline-row strong,
+.artifact-table-head span,
+.record-facts-row strong,
+.recent-conversation-copy strong {
+  color: var(--text-main);
+}
+
+.timeline-row p,
+.record-facts-row p,
+.recent-conversation-copy p,
+.empty-inline-card p {
+  margin: 0;
+  color: var(--text-soft);
+  overflow-wrap: anywhere;
+}
+
+.artifact-table {
+  display: grid;
+  gap: 4px;
+}
+
+.artifact-table-head,
+.artifact-table-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) 0.72fr 0.72fr 48px;
+  gap: 10px;
+  align-items: center;
+}
+
+.artifact-table-head {
+  padding: 0 0 10px;
+  color: var(--text-faint);
+  font-size: 0.88rem;
+}
+
+.artifact-table-row {
+  padding: 12px 0;
+  border-top: 1px solid rgba(151, 179, 235, 0.12);
+  color: var(--text-soft);
+}
+
+.artifact-file-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.artifact-file-cell span {
+  overflow-wrap: anywhere;
+}
+
+.artifact-download-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  border: 1px solid rgba(151, 179, 235, 0.18);
+  background: rgba(246, 250, 255, 0.95);
+  color: var(--blue);
+}
+
+.record-facts-row {
+  display: grid;
+  grid-template-columns: 88px minmax(0, 1fr);
+  gap: 10px;
+  align-items: start;
+}
+
+.record-facts-row-top {
+  align-items: start;
+}
+
+.record-facts-row span {
+  color: var(--text-faint);
+}
+
+.record-facts-row code {
+  color: #48638e;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.recent-conversation-row {
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: start;
+}
+
+.recent-conversation-avatar {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 999px;
+  color: white;
+  font-weight: 800;
+}
+
+.recent-conversation-avatar-user {
+  background: linear-gradient(180deg, #4d98ff 0%, #216eff 100%);
+}
+
+.recent-conversation-avatar-assistant {
+  background: linear-gradient(180deg, #49caa3 0%, #24ac7d 100%);
+}
+
+.recent-conversation-copy {
+  display: grid;
+  gap: 4px;
+}
+
+.recent-conversation-time {
+  color: var(--text-faint);
+  font-size: 0.84rem;
+}
+
+.empty-inline-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: 18px;
+  border: 1px dashed rgba(151, 179, 235, 0.22);
+  background: rgba(247, 250, 255, 0.96);
+}
+
+.empty-inline-card strong {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--text-main);
+}
+
 .empty-state {
   display: grid;
   gap: 8px;
@@ -813,11 +1743,12 @@ code {
 
 .settings-content-single,
 .settings-content-stack {
-  min-height: 0;
+  min-height: auto;
   display: grid;
   gap: 16px;
-  overflow: auto;
-  padding-right: 2px;
+  overflow: visible;
+  padding-right: 0;
+  align-content: start;
 }
 
 .settings-content-single {
@@ -895,6 +1826,7 @@ code {
 .settings-select,
 .settings-textarea {
   width: 100%;
+  min-width: 0;
   border-radius: 18px;
   border: 1px solid var(--line-strong);
   background: rgba(255, 255, 255, 0.9);
@@ -909,6 +1841,33 @@ code {
 .settings-textarea:focus {
   border-color: rgba(255, 179, 138, 0.48);
   box-shadow: 0 0 0 4px rgba(255, 179, 138, 0.12);
+}
+
+.settings-select {
+  appearance: none;
+  cursor: pointer;
+  padding-right: 48px;
+  background-image:
+    linear-gradient(180deg, rgba(255, 252, 248, 0.98), rgba(255, 243, 236, 0.98)),
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='%23c67856' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat, no-repeat;
+  background-position: center center, right 16px center;
+  background-size: 100% 100%, 18px 18px;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.94),
+    0 8px 18px rgba(183, 132, 96, 0.05);
+}
+
+.settings-select:hover:not(:disabled) {
+  border-color: rgba(255, 179, 138, 0.34);
+}
+
+.settings-select:disabled {
+  cursor: not-allowed;
+  color: var(--text-faint);
+  background-image:
+    linear-gradient(180deg, rgba(250, 245, 240, 0.95), rgba(245, 237, 231, 0.96)),
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='%23b79c8f' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
 }
 
 .checkbox-row {
@@ -1041,6 +2000,11 @@ code {
   overflow: auto;
 }
 
+.settings-shell {
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
 .settings-login-grid,
 .settings-login-confirm {
   display: grid;
@@ -1141,6 +2105,31 @@ code {
   color: #ab5160;
 }
 
+@media (max-width: 1480px) {
+  .dashboard-shell {
+    overflow-y: auto;
+  }
+
+  .dashboard-reference-grid {
+    flex: none;
+    min-height: auto;
+    grid-template-columns: minmax(280px, 340px) minmax(0, 1fr);
+  }
+
+  .dashboard-right-column {
+    grid-column: 1 / -1;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-rows: auto auto;
+  }
+
+  .dashboard-rail-card .section-card-body,
+  .dashboard-main-card .section-card-body,
+  .dashboard-side-card .section-card-body {
+    overflow: visible;
+    padding-right: 0;
+  }
+}
+
 @media (max-width: 1180px) {
   .app-shell {
     grid-template-columns: 1fr;
@@ -1175,6 +2164,36 @@ code {
 
   .dashboard-stage {
     grid-template-rows: auto auto;
+  }
+
+  .dashboard-header {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard-header-stats,
+  .dashboard-reference-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard-right-column {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto;
+  }
+
+  .task-detail-hero,
+  .task-detail-meta-grid,
+  .task-detail-bottom-grid,
+  .task-progress-steps,
+  .artifact-table-head,
+  .artifact-table-row,
+  .timeline-row {
+    grid-template-columns: 1fr;
+  }
+
+  .task-progress-head,
+  .dashboard-title-row {
+    flex-direction: column;
+    align-items: flex-start;
   }
 
   .settings-content-single,
@@ -1212,11 +2231,29 @@ code {
     grid-template-columns: 1fr;
   }
 
+  .task-list-summary-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .dashboard-stat-card strong {
+    font-size: 1.6rem;
+  }
+
+  .task-teaser-head,
+  .recent-conversation-row {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
   .pill-tabs {
-    padding-bottom: 6px;
+    padding-bottom: 0;
+  }
+
+  .settings-pill-tabs {
+    grid-template-columns: 1fr;
   }
 
   .pill-tab {
-    min-width: 146px;
+    min-width: 0;
   }
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -2,9 +2,11 @@ export type TaskState = 'accepted' | 'running' | 'completed' | 'failed' | 'cance
 
 export type Task = {
   id: string
+  plugin?: string
   kind: string
   title: string
   input: string
+  parent_task_id?: string
   state: TaskState
   summary: string
   result: string


### PR DESCRIPTION
## 变更说明
- 完全重做前端控制台的整体壳层，从顶部导航改成左侧主导航 + 右侧主工作区，重新梳理页面层级
- 整体视觉改为更轻、更可爱、更柔和的浅色风格，去掉偏技术化、过重或不合适的描述
- Dashboard 重构为任务队列 / 任务工作台 / 最近会话三段式，不再把系统设置混进任务页
- Settings 重构为“配置域导航 + IM 子标签工作区”，避免所有设置面板堆成一条长页面
- Logs 重构为轻量分页控制 + 紧凑日志流，减少大卡片堆叠带来的阅读负担
- 新增一批通用 UI 组件与页面组件，明显提升前端组件化程度
- 引入 `lucide-react` 作为轻量图标库，统一导航和状态图标风格

## 这次重点解决的问题
- 菜单层级和页面结构不清晰
- 页面容易出现不必要的整体滑动和长滚动堆叠
- 任务页、设置页、日志页之间的信息边界不够明确
- 局部描述过于技术导向，不像产品界面
- 页面组件职责过大、复用不够明显

## 设计调整
- 使用固定视口壳层，桌面端由内部工作区负责滚动，避免整页意外双滚动
- 使用统一的卡片、标签页、空状态、状态徽章组件
- 设置页增加 IM 子标签：镜像规则 / 手动调试 / 微信账号 / 触达对象
- Dashboard 细化为任务选择与任务详情分区，并把任务详情再拆成概览 / 产物 / 轨迹 / Claude 执行器标签
- 浏览器标题同步调整为 `XiaoAiAgent 控制台`

## 验证
- `npm run build:web`
- `GOCACHE=$(pwd)/.gocache go test ./...`
