### PR TITLE
feat: 优化 continue_task 任务链意图识别

### DIFF
--- a/docs/feature-overview.md
+++ b/docs/feature-overview.md
@@ -50,6 +50,7 @@
 
 - 支持把用户输入路由成普通聊天、工具调用、异步任务、继续任务、查询任务等不同路径
 - 工具结果通常不会原样机械播报，而是经过 `reply` 模型整理后再回复
+- `continue_task` 的候选不是零散 task 行，而是按任务链折叠后的快照
 - 当前内置工具包括：
   - `ask_weather`
   - `ask_stock`
@@ -58,6 +59,10 @@
   - `query_task_progress`
   - `cancel_task`
   - `continue_task`
+
+工具意图识别的具体拼接方式，可参考：
+
+- `docs/tool-intent-routing.md`
 
 ### 2.4 异步任务系统
 

--- a/docs/tool-intent-routing.md
+++ b/docs/tool-intent-routing.md
@@ -1,0 +1,191 @@
+# 工具意图识别机制
+
+这份文档只讲一件事：XiaoAiAgent 在意图识别阶段，怎么判断当前一句话应该走普通聊天、取数工具、本机任务，还是命中 `continue_task`。
+
+它不是完整的任务系统设计文档，只解释“给 intent 模型看什么上下文，为什么这么拼”。
+
+## 1. 总体分流
+
+当前意图识别阶段的核心分流是：
+
+- 普通聊天、解释、建议、延伸问答：`continue_chat`
+- 明确取数：例如 `ask_weather`、`ask_stock`
+- 明确要在本机落地产出物或执行多步骤任务：`complex_task`
+- 明确是在补充、修改、继续之前已经完成的任务：`continue_task`
+- 明确是在追当前还没做完的任务状态：`query_task_progress`
+
+也就是说，意图识别不是只看“像不像工具调用”，而是要先区分：
+
+- 这是新的任务
+- 这是普通对话
+- 这是在继续以前做过的那件事
+- 这是在追当前任务进度
+
+## 2. 为什么 `continue_task` 不能只看单个 task
+
+`continue_task` 每续做一次，系统都会新建一条新的 task 记录，并通过 `parent_task_id` 串起来。
+
+如果直接把最近完成的 task 行平铺给模型，会有两个问题：
+
+1. 同一条任务链可能出现多次  
+   模型容易选到已经过期的旧 `task_id`
+
+2. 只有最新摘要，没有原始输入  
+   用户如果按“最开始那件事”来提起任务，模型缺少原始语义锚点
+
+所以 `continue_task` 的候选上下文，不应该按“单条 task”拼，而应该按“任务链快照”拼。
+
+## 3. continue_task 的任务链快照
+
+当前给 intent 模型的 `continue_task` 候选，每条只代表一条任务链当前最新的已完成节点。
+
+每条快照会带这些字段：
+
+- `latest_task_id`
+  这条链当前最新的已完成任务 ID
+- `plugin`
+  这条链应该命中的执行插件
+- `root_title`
+  根任务标题
+- `root_input`
+  根任务最开始的用户输入
+- `recent_followups`
+  最近几次续做任务的输入摘要
+- `latest_summary`
+  当前最新已完成节点的摘要
+
+这样一条快照同时表达了两层信息：
+
+- 这条链最开始到底是干什么的
+- 这条链最近已经改到哪一步
+
+## 4. 为什么这样拼
+
+因为用户继续任务时，提法通常有两种：
+
+### 情况 A：按根任务语义提
+
+例如：
+
+- “那个天气小游戏再加个音效”
+
+这里模型更需要依赖：
+
+- `root_title`
+- `root_input`
+
+### 情况 B：按最近续做语义提
+
+例如：
+
+- “刚刚那个再炫酷一点”
+- “在上次那个基础上继续改”
+
+这里模型更需要依赖：
+
+- `recent_followups`
+- `latest_summary`
+
+所以 `continue_task` 的候选上下文必须同时保留：
+
+- 根任务锚点
+- 最近续做轨迹
+
+## 5. 两个具体 case
+
+### Case 1：只有根任务，没有后续续做
+
+用户最开始说：
+
+- “帮我做一个关于天气的小游戏”
+
+任务完成后，候选快照可能是：
+
+```text
+- latest_task_id=task_100
+  plugin=complex_task
+  root_title=天气小游戏
+  root_input=帮我做一个关于天气的小游戏
+  recent_followups=无
+  latest_summary=已经做出一个可玩的天气小游戏网页
+```
+
+如果用户后面说：
+
+- “那个天气小游戏再加个音效”
+
+模型就应该命中：
+
+- `continue_task`
+- `plugin_name=complex_task`
+- `task_id=task_100`
+- `request=再加个音效`
+
+### Case 2：已经续做过多次
+
+根任务：
+
+- “帮我做一个关于天气的小游戏”
+
+后续两次续做：
+
+- “加一点动画”
+- “再炫酷一点”
+
+这时候选快照应该折叠成一条：
+
+```text
+- latest_task_id=task_130
+  plugin=complex_task
+  root_title=天气小游戏
+  root_input=帮我做一个关于天气的小游戏
+  recent_followups=加一点动画；再炫酷一点
+  latest_summary=当前版本已经加入更强的动画效果和视觉强化
+```
+
+如果用户这次说：
+
+- “刚刚那个天气小游戏再加个音效”
+
+模型仍然应该命中：
+
+- `continue_task`
+- `plugin_name=complex_task`
+- `task_id=task_130`
+
+注意，这里命中的不是根任务 `task_100`，而是这条链当前最新的已完成节点 `task_130`。
+
+## 6. 对 prompt 的影响
+
+优化后，意图识别 prompt 里会明确告诉模型：
+
+- 下面给出的不是普通 task 行，而是“任务链快照”
+- 每条快照只代表一条链当前最新的已完成节点
+- 判断 `continue_task` 时，要结合：
+  - `root_title`
+  - `root_input`
+  - `recent_followups`
+  - `latest_summary`
+- 真正调用 `continue_task` 时：
+  - `task_id` 必须填写 `latest_task_id`
+  - `plugin_name` 必须填写 `plugin`
+
+## 7. 当前刻意不做的事
+
+当前这套机制先不处理：
+
+- 最新节点还在 `running` 时对任务追加新指令
+- 一条链同时展示多个历史节点给模型
+- 用完整 `result` 全量拼进 prompt
+
+原因很直接：
+
+- `running` 更像进度查询或未来的“运行中追加指令”能力
+- 候选里重复展示旧节点会让模型更容易续错
+- 全量 `result` 太长，会明显挤占 prompt 预算
+
+所以当前设计收敛为：
+
+- 每条任务链只展示一个快照
+- 只命中最新的已完成节点
+- 用根输入 + 最近续做 + 最新摘要来平衡语义完整度和 prompt 大小

--- a/internal/llm/intent.go
+++ b/internal/llm/intent.go
@@ -2,7 +2,6 @@ package llm
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"strings"
@@ -11,20 +10,10 @@ import (
 )
 
 type IntentDecision struct {
-	ShouldHandle  bool   `json:"should_handle"`
-	ShouldAbort   bool   `json:"should_abort"`
-	ReplyRequired bool   `json:"reply_required"`
-	Reason        string `json:"reason"`
-	ToolCall      *ToolCall
-}
-
-type intentJSONDecision struct {
-	ShouldHandle  bool            `json:"should_handle"`
-	ShouldAbort   bool            `json:"should_abort"`
-	ReplyRequired bool            `json:"reply_required"`
-	Reason        string          `json:"reason"`
-	ToolName      string          `json:"tool_name"`
-	ToolArguments json.RawMessage `json:"tool_arguments"`
+	ShouldHandle bool   `json:"should_handle"`
+	ShouldAbort  bool   `json:"should_abort"`
+	Reason       string `json:"reason"`
+	ToolCall     *ToolCall
 }
 
 type IntentRecognizer struct {
@@ -63,17 +52,18 @@ func NewIntentRecognizer(client *Client, cfg config.ModelConfig, tools ToolDefin
 // Decide 对当前这轮用户输入做一次“主流程路由判定”。
 //
 // 它不会直接生成最终播报给用户的回复，而是把当前 text、最近会话 history、
-// 可用工具定义以及最近已完成任务摘要一起发给 intent 模型，让模型判断：
+// 可用工具定义以及最近可继续的任务链快照一起发给 intent 模型，让模型判断：
 // 1. 这轮是否应该继续走普通聊天 reply；
 // 2. 是否应该命中某个同步工具；
 // 3. 是否应该受理为 complex_task / continue_task / query_task_progress 等特殊工具调用。
 //
-// 返回值兼容两种模型行为：
-// 1. 模型直接按 OpenAI tool call 机制返回工具调用；
-// 2. 模型没有稳定返回 tool call，而是退化成固定 JSON，由这里再还原成 IntentDecision。
+// 返回值预期为原生 OpenAI tool call。
+// 当前策略下，intent 模型总是要从已注册工具里选一个：
+// - 普通聊天、解释、建议、延伸问答 => continue_chat
+// - 查天气、查股票、复杂任务、续任务、查进度、取消任务 => 对应工具
 //
 // assistant.Service 会消费这份 IntentDecision，
-// 决定主流程后续进入 reply、tool 还是 async task 分支。
+// 决定主流程后续进入普通 reply、tool 还是 async task 分支。
 func (r *IntentRecognizer) Decide(ctx context.Context, history []Message, text string) (IntentDecision, error) {
 	availableTools := []ToolDefinition(nil)
 	if r.tools != nil {
@@ -92,46 +82,24 @@ func (r *IntentRecognizer) Decide(ctx context.Context, history []Message, text s
 		{
 			Role: "system",
 			Content: strings.TrimSpace(`
-	你是一个小爱音箱外部接管器的工具路由器。你只能返回 JSON，不要返回任何额外文本。
+	你是一个小爱音箱外部接管器的工具路由器。
 
 	当前系统策略是：拿到 ASR 结果后，外部助手始终接管并负责回复，不再回退给原生小爱。
 
-你的任务只有两个：
-	1. 如果用户请求明确命中了某个已注册工具，直接发起 tool call，而不是返回 JSON。
-	2. 如果不命中工具，返回固定结构的 JSON，表示继续由外部大模型回复。
-
-	每次最多调用一个工具。
-
-	如果当前模型没有可靠返回原生 tool call，也允许你退化为 JSON，并额外补两个字段：
-	- "tool_name": 工具名
-	- "tool_arguments": 工具参数对象
-	只要需要调用工具，就必须提供这两个字段中的 tool_name，tool_arguments 没参数时返回 {}。
-
-	返回 JSON，字段固定如下：
-	{
-	  "should_handle": true,
-	  "should_abort": true,
-	  "reply_required": true,
-	  "reason": "简短原因",
-	  "tool_name": "",
-	  "tool_arguments": {}
-	}
-
 	规则：
-	1. 如果明确命中已注册工具，直接调用工具，不要输出 JSON。
-	2. 如果必须退化成 JSON 调工具，should_handle=true，should_abort=true，reply_required=false，并填写 tool_name/tool_arguments。
-	3. 如果不调用工具，should_handle=true，should_abort=true，reply_required=true。
-	4. reason 用一句短中文说明为什么调用工具，或者为什么不调用工具，改由主回复模型回答。
-	5. 如果不调用工具，输出必须是合法 JSON。
-	6. 工具只负责取数或执行明确动作，不负责基于已有上下文做建议、解释或延伸聊天。
-	7. 对天气工具尤其要严格区分：
+	1. 当用户只是普通聊天、解释、建议、总结、延伸问答、不需要任何外部动作或取数时，调用 continue_chat。
+	2. 工具只负责取数或执行明确动作，不负责基于已有上下文做建议、解释或延伸聊天。
+	3. 对天气工具尤其要严格区分：
 	   - 如果用户明确要求查询、确认、刷新某个城市/地区的天气，才调用天气工具。
-	   - 如果用户是在已有天气结果基础上继续追问“那穿什么衣服”“要不要带伞”“适不适合出门”“那我该注意什么”这类建议问题，不要调用天气工具，直接走主回复模型。
-	8. 如果当前问题没有提供新的城市/地区信息，而且从上下文看已经拿到天气结果，优先认为这是延伸问答，不要重复调用天气工具。
-	9. 如果用户明确要求你在当前电脑上实际做事，例如创建文件、修改文件、整理桌面、生成网页、写文档、执行命令、完成一个需要落地产出的多步骤任务，优先调用 complex_task，而不是直接走普通聊天回复。
-	10. 对“操作电脑”“帮我在桌面放一个文件”“帮我做个网页并保存下来”“帮我整理一个文档”这类请求，只要需要本机执行和产出物，就优先视为 complex_task。
-	11. 如果用户是在补充、修改、继续之前已经完成的任务，例如“刚刚那个网页再加一个按钮”“把上次那个文件改一下”“在刚才那个任务基础上继续做”，优先调用 continue_task。
-	12. 调用 continue_task 时，必须提供 plugin_name、task_id、request 三个字段。plugin_name 和 task_id 必须从已完成任务列表里选择，不要编造。
+	   - 如果用户是在已有天气结果基础上继续追问“那穿什么衣服”“要不要带伞”“适不适合出门”“那我该注意什么”这类建议问题，不要调用天气工具，调用 continue_chat。
+	4. 如果当前问题没有提供新的城市/地区信息，而且从上下文看已经拿到天气结果，优先认为这是延伸问答，不要重复调用天气工具，调用 continue_chat。
+	5. 如果用户明确要求你在当前电脑上实际做事，例如创建文件、修改文件、整理桌面、生成网页、写文档、执行命令、完成一个需要落地产出的多步骤任务，优先调用 complex_task，而不是 continue_chat。
+	6. 对“操作电脑”“帮我在桌面放一个文件”“帮我做个网页并保存下来”“帮我整理一个文档”这类请求，只要需要本机执行和产出物，就优先视为 complex_task。
+	7. 如果用户是在补充、修改、继续之前已经完成的任务，例如“刚刚那个网页再加一个按钮”“把上次那个文件改一下”“在刚才那个任务基础上继续做”，优先调用 continue_task。
+	8. 当你判断是否命中 continue_task 时，要结合任务链快照里的 root_title、root_input、recent_followups、latest_summary 一起理解，不要只看其中一个字段。
+	9. 调用 continue_task 时，必须提供 plugin_name、task_id、request 三个字段。plugin_name 和 task_id 必须从任务链快照里选择，不要编造。
+	10. 如果任务链快照里给出了 latest_task_id，那么 task_id 必须填写这个 latest_task_id，不要回退到更早的根任务 ID。
+	11. 如果用户这次更像是在追一个仍在执行中的任务状态，而不是继续一个已经完成的任务，不要调用 continue_task，优先考虑 query_task_progress。
 	`),
 		},
 		{
@@ -140,6 +108,15 @@ func (r *IntentRecognizer) Decide(ctx context.Context, history []Message, text s
 		},
 	}
 	if r.taskContext != nil {
+		// 这里插入的是“最近已完成任务候选列表”。
+		// intent 模型在判断要不要调用 continue_task 之前，
+		// 就会先看到这段 system message，再结合当前 ASR 文本做匹配。
+		//
+		// 当前候选列表来自 tasks.Manager.CompletedTasksForIntent(5)：
+		// - 不是平铺 task 行，而是按 parent_task_id 折叠成任务链快照
+		// - 每条快照只暴露这条链当前最新的 completed 节点
+		// - 每条快照同时带 root_input 和 recent_followups，兼顾原始目标和最近修改语义
+		// - 最多带 5 条，避免把过多旧任务塞进 prompt
 		completedTasks := strings.TrimSpace(r.taskContext.CompletedTasksForIntent(5))
 		if completedTasks != "" {
 			messages = append(messages[:1], append([]Message{{Role: "system", Content: completedTasks}}, messages[1:]...)...)
@@ -151,9 +128,20 @@ func (r *IntentRecognizer) Decide(ctx context.Context, history []Message, text s
 		messages = append(prefix, append(history, currentUser)...)
 	}
 
+	log.Printf(
+		"intent request prepared: model=%s tool_count=%d history_count=%d messages=\n%s",
+		strings.TrimSpace(r.config.Model),
+		len(availableTools),
+		len(history),
+		formatIntentMessagesForLog(messages),
+	)
+	if len(availableTools) > 0 {
+		log.Printf("intent request tools: %s", strings.Join(toolNamesForLog(availableTools), ", "))
+	}
+
 	// 这里把已注册工具定义一并传给模型：
-	// 如果模型稳定支持 OpenAI tool call，就可能直接返回某个 tool call；
-	// 否则会退化成普通文本 / JSON，再由下面的逻辑继续解析。
+	// 当前策略要求模型始终返回一个原生 tool call，
+	// 普通聊天场景也通过 continue_chat 这个逻辑工具来表达。
 	result, err := r.client.CompleteWithTools(ctx, r.config, messages, 0, availableTools)
 	if err != nil {
 		return IntentDecision{}, err
@@ -163,124 +151,45 @@ func (r *IntentRecognizer) Decide(ctx context.Context, history []Message, text s
 		call := result.ToolCalls[0]
 		log.Printf("intent tool selected via native tool_call: tool=%s", strings.TrimSpace(call.Name))
 		return IntentDecision{
-			ShouldHandle:  true,
-			ShouldAbort:   true,
-			ReplyRequired: false,
-			Reason:        fmt.Sprintf("tool call: %s", call.Name),
-			ToolCall:      &call,
+			ShouldHandle: true,
+			ShouldAbort:  true,
+			Reason:       fmt.Sprintf("tool call: %s", call.Name),
+			ToolCall:     &call,
 		}, nil
 	}
 
-	jsonText, err := extractJSONObject(result.Content)
-	if err != nil {
-		return IntentDecision{}, fmt.Errorf("extract intent json: %w", err)
-	}
-
-	var decision IntentDecision
-	var raw intentJSONDecision
-	if err := json.Unmarshal([]byte(jsonText), &raw); err != nil {
-		return IntentDecision{}, fmt.Errorf("decode intent json: %w", err)
-	}
-
-	decision = IntentDecision{
-		ShouldHandle:  raw.ShouldHandle,
-		ShouldAbort:   raw.ShouldAbort,
-		ReplyRequired: raw.ReplyRequired,
-		Reason:        raw.Reason,
-	}
-
-	if toolName, ok := resolveToolName(raw.ToolName, raw.Reason, result.Content, availableTools); ok {
-		arguments := raw.ToolArguments
-		if len(arguments) == 0 {
-			arguments = json.RawMessage(`{}`)
-		}
-		log.Printf("intent tool selected via json fallback: tool=%s", strings.TrimSpace(toolName))
-		decision.ToolCall = &ToolCall{
-			Name:      toolName,
-			Arguments: arguments,
-		}
-		decision.ShouldHandle = true
-		decision.ShouldAbort = true
-		decision.ReplyRequired = false
-	}
-
-	if decision.ShouldHandle && decision.ReplyRequired && !decision.ShouldAbort {
-		decision.ShouldAbort = true
-	}
-
-	return decision, nil
+	return IntentDecision{}, fmt.Errorf("intent completion returned no tool call")
 }
 
-func resolveToolName(explicitName string, reason string, content string, tools []ToolDefinition) (string, bool) {
-	explicitName = strings.TrimSpace(explicitName)
-	if explicitName != "" {
-		for _, tool := range tools {
-			if explicitName == tool.Name {
-				return explicitName, true
-			}
-		}
+func formatIntentMessagesForLog(messages []Message) string {
+	if len(messages) == 0 {
+		return "(empty)"
 	}
 
-	searchSpace := reason + "\n" + content
-	matched := ""
+	var lines []string
+	for index, message := range messages {
+		lines = append(lines, fmt.Sprintf(
+			"[%d] role=%s content=%q",
+			index,
+			strings.TrimSpace(message.Role),
+			strings.TrimSpace(message.Content),
+		))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func toolNamesForLog(tools []ToolDefinition) []string {
+	if len(tools) == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(tools))
 	for _, tool := range tools {
-		if tool.Name == "" {
-			continue
+		name := strings.TrimSpace(tool.Name)
+		if name == "" {
+			name = "(unnamed)"
 		}
-		if strings.Contains(searchSpace, tool.Name) {
-			if matched != "" && matched != tool.Name {
-				return "", false
-			}
-			matched = tool.Name
-		}
+		names = append(names, name)
 	}
-	if matched != "" {
-		return matched, true
-	}
-
-	return "", false
-}
-
-func extractJSONObject(text string) (string, error) {
-	start := strings.IndexByte(text, '{')
-	if start == -1 {
-		return "", fmt.Errorf("no json object found")
-	}
-
-	depth := 0
-	inString := false
-	escaped := false
-
-	for i := start; i < len(text); i++ {
-		ch := text[i]
-
-		if inString {
-			if escaped {
-				escaped = false
-				continue
-			}
-			if ch == '\\' {
-				escaped = true
-				continue
-			}
-			if ch == '"' {
-				inString = false
-			}
-			continue
-		}
-
-		switch ch {
-		case '"':
-			inString = true
-		case '{':
-			depth++
-		case '}':
-			depth--
-			if depth == 0 {
-				return text[start : i+1], nil
-			}
-		}
-	}
-
-	return "", fmt.Errorf("unterminated json object")
+	return names
 }

--- a/internal/llm/intent_test.go
+++ b/internal/llm/intent_test.go
@@ -3,8 +3,10 @@ package llm
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/config"
@@ -18,14 +20,23 @@ func (p staticToolProvider) Definitions() []ToolDefinition {
 	return p.tools
 }
 
+type staticCompletedTaskProvider struct {
+	text string
+}
+
+func (p staticCompletedTaskProvider) CompletedTasksForIntent(limit int) string {
+	return p.text
+}
+
 func TestIntentRecognizerDecide(t *testing.T) {
 	t.Parallel()
 
-	t.Run("decodes json decision", func(t *testing.T) {
+	t.Run("returns continue_chat tool when model chooses normal chat", func(t *testing.T) {
 		t.Parallel()
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprint(w, `{"choices":[{"message":{"content":"{\"should_handle\":true,\"should_abort\":true,\"reply_required\":true,\"reason\":\"开放式问答\"}"}}]}`)
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"choices":[{"message":{"content":"","tool_calls":[{"id":"call_1","type":"function","function":{"name":"continue_chat","arguments":"{}"}}]}}]}`)
 		}))
 		defer server.Close()
 
@@ -33,22 +44,37 @@ func TestIntentRecognizerDecide(t *testing.T) {
 			Model:   "intent-model",
 			BaseURL: server.URL,
 			APIKey:  "test-key",
-		}, nil, nil)
+		}, staticToolProvider{
+			tools: []ToolDefinition{
+				{
+					Name:        "continue_chat",
+					Description: "继续普通聊天",
+					InputSchema: map[string]any{"type": "object"},
+				},
+			},
+		}, nil)
 
 		decision, err := recognizer.Decide(context.Background(), nil, "解释一下量子纠缠")
 		if err != nil {
 			t.Fatalf("Decide() error = %v", err)
 		}
-		if !decision.ShouldHandle || !decision.ShouldAbort || !decision.ReplyRequired {
-			t.Fatalf("decision = %+v, want handle+abort+reply", decision)
+		if decision.ToolCall == nil {
+			t.Fatalf("decision.ToolCall = nil, want non-nil")
+		}
+		if decision.ToolCall.Name != "continue_chat" {
+			t.Fatalf("decision.ToolCall.Name = %q", decision.ToolCall.Name)
+		}
+		if !decision.ShouldHandle || !decision.ShouldAbort {
+			t.Fatalf("decision = %+v, want handle+abort", decision)
 		}
 	})
 
-	t.Run("extracts json from wrapped content", func(t *testing.T) {
+	t.Run("returns error when model emits no tool call", func(t *testing.T) {
 		t.Parallel()
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprint(w, `{"choices":[{"message":{"content":"结果如下：\n{\"should_handle\":false,\"should_abort\":false,\"reply_required\":false,\"reason\":\"原生设备控制\"}"}}]}`)
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"choices":[{"message":{"content":"普通文本，没有工具调用"}}]}`)
 		}))
 		defer server.Close()
 
@@ -58,12 +84,8 @@ func TestIntentRecognizerDecide(t *testing.T) {
 			APIKey:  "test-key",
 		}, nil, nil)
 
-		decision, err := recognizer.Decide(context.Background(), nil, "打开客厅空调")
-		if err != nil {
-			t.Fatalf("Decide() error = %v", err)
-		}
-		if decision.ShouldHandle {
-			t.Fatalf("decision = %+v, want should_handle=false", decision)
+		if _, err := recognizer.Decide(context.Background(), nil, "打开客厅空调"); err == nil {
+			t.Fatalf("Decide() error = nil, want non-nil")
 		}
 	})
 
@@ -71,6 +93,7 @@ func TestIntentRecognizerDecide(t *testing.T) {
 		t.Parallel()
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
 			fmt.Fprint(w, `{"choices":[{"message":{"content":"","tool_calls":[{"id":"call_1","type":"function","function":{"name":"ask_weather","arguments":"{\"city\":\"上海\"}"}}]}}]}`)
 		}))
 		defer server.Close()
@@ -99,16 +122,23 @@ func TestIntentRecognizerDecide(t *testing.T) {
 		if decision.ToolCall.Name != "ask_weather" {
 			t.Fatalf("decision.ToolCall.Name = %q", decision.ToolCall.Name)
 		}
-		if !decision.ShouldHandle || !decision.ShouldAbort || decision.ReplyRequired {
-			t.Fatalf("decision = %+v, want handle+abort and no reply", decision)
+		if !decision.ShouldHandle || !decision.ShouldAbort {
+			t.Fatalf("decision = %+v, want handle+abort", decision)
 		}
 	})
 
-	t.Run("returns tool call when model encodes tool_name in json", func(t *testing.T) {
+	t.Run("injects task chain snapshot prompt into intent request", func(t *testing.T) {
 		t.Parallel()
 
+		var requestBody string
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprint(w, `{"choices":[{"message":{"content":"{\"should_handle\":true,\"should_abort\":true,\"reply_required\":false,\"reason\":\"用户询问功能列表，需要调用工具\",\"tool_name\":\"list_tools\",\"tool_arguments\":{}}"}}]}`)
+			raw, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("ReadAll() error = %v", err)
+			}
+			requestBody = string(raw)
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"choices":[{"message":{"content":"","tool_calls":[{"id":"call_1","type":"function","function":{"name":"continue_task","arguments":"{\"plugin_name\":\"complex_task\",\"task_id\":\"task_130\",\"request\":\"刚刚那个天气小游戏再加个音效\"}"}}]}}]}`)
 		}))
 		defer server.Close()
 
@@ -119,62 +149,45 @@ func TestIntentRecognizerDecide(t *testing.T) {
 		}, staticToolProvider{
 			tools: []ToolDefinition{
 				{
-					Name:        "list_tools",
-					Description: "查看能力列表",
+					Name:        "continue_task",
+					Description: "续任务",
 					InputSchema: map[string]any{"type": "object"},
 				},
 			},
-		}, nil)
+		}, staticCompletedTaskProvider{
+			text: strings.TrimSpace(`
+下面是最近可继续的任务链快照。每条只代表一条任务链当前最新的已完成节点。
+如果用户现在是在补充、修改、继续之前已经做完的任务，请优先从下面选择最匹配的一条，并调用 continue_task。
+注意：调用 continue_task 时，task_id 必须填写 latest_task_id，plugin_name 必须填写 plugin，不要自己编造。
 
-		decision, err := recognizer.Decide(context.Background(), nil, "你能做什么")
+- latest_task_id=task_130
+  plugin=complex_task
+  root_title=天气小游戏
+  root_input=帮我做一个关于天气的小游戏
+  recent_followups=加一点动画；再炫酷一点
+  latest_summary=当前版本已经加入更强的动画效果和视觉强化
+`),
+		})
+
+		decision, err := recognizer.Decide(context.Background(), nil, "刚刚那个天气小游戏再加个音效")
 		if err != nil {
 			t.Fatalf("Decide() error = %v", err)
 		}
-		if decision.ToolCall == nil {
-			t.Fatalf("decision.ToolCall = nil, want non-nil")
+		if decision.ToolCall == nil || decision.ToolCall.Name != "continue_task" {
+			t.Fatalf("decision.ToolCall = %#v, want continue_task", decision.ToolCall)
 		}
-		if decision.ToolCall.Name != "list_tools" {
-			t.Fatalf("decision.ToolCall.Name = %q", decision.ToolCall.Name)
-		}
-		if decision.ReplyRequired {
-			t.Fatalf("decision.ReplyRequired = true, want false")
-		}
-	})
 
-	t.Run("matches tool from reason fallback", func(t *testing.T) {
-		t.Parallel()
-
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprint(w, `{"choices":[{"message":{"content":"{\"should_handle\":true,\"should_abort\":true,\"reply_required\":true,\"reason\":\"用户询问功能列表，需要调用 list_tools 工具\"}"}}]}`)
-		}))
-		defer server.Close()
-
-		recognizer := NewIntentRecognizer(NewClient(), config.ModelConfig{
-			Model:   "intent-model",
-			BaseURL: server.URL,
-			APIKey:  "test-key",
-		}, staticToolProvider{
-			tools: []ToolDefinition{
-				{
-					Name:        "list_tools",
-					Description: "查看能力列表",
-					InputSchema: map[string]any{"type": "object"},
-				},
-			},
-		}, nil)
-
-		decision, err := recognizer.Decide(context.Background(), nil, "你能做什么")
-		if err != nil {
-			t.Fatalf("Decide() error = %v", err)
-		}
-		if decision.ToolCall == nil {
-			t.Fatalf("decision.ToolCall = nil, want non-nil")
-		}
-		if decision.ToolCall.Name != "list_tools" {
-			t.Fatalf("decision.ToolCall.Name = %q", decision.ToolCall.Name)
-		}
-		if decision.ReplyRequired {
-			t.Fatalf("decision.ReplyRequired = true, want false")
+		for _, expected := range []string{
+			"最近可继续的任务链快照",
+			"latest_task_id",
+			"root_input",
+			"recent_followups",
+			"task_id 必须填写这个 latest_task_id",
+			"刚刚那个天气小游戏再加个音效",
+		} {
+			if !strings.Contains(requestBody, expected) {
+				t.Fatalf("request body missing %q in %q", expected, requestBody)
+			}
 		}
 	})
 }

--- a/internal/plugins/continuetask/plugin.go
+++ b/internal/plugins/continuetask/plugin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/luoliwoshang/open-xiaoai-agent/internal/plugin"
@@ -53,17 +54,17 @@ func Register(registry *plugin.Registry, manager TaskLookup, resumes *ResumeRegi
 		Definition: plugin.Definition{
 			Name:        "continue_task",
 			Summary:     "续任务",
-			Description: "接续一个之前已经完成的异步任务。当用户是在补充、修改、继续之前做完的网页、文档、文件或电脑任务时调用。必须提供 plugin_name、task_id 和新的补充要求 request。",
+			Description: "接续一个之前已经完成的异步任务。当用户是在补充、修改、继续之前做完的网页、文档、文件或电脑任务时调用。必须提供 plugin_name、task_id 和新的补充要求 request。task_id 应该指向那条任务链当前最新的已完成节点。",
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
 					"plugin_name": map[string]any{
 						"type":        "string",
-						"description": "要接续的任务所属插件名，例如 complex_task。",
+						"description": "要接续的任务链所属插件名，例如 complex_task。",
 					},
 					"task_id": map[string]any{
 						"type":        "string",
-						"description": "要接续的已完成任务 ID。",
+						"description": "要接续的任务链当前最新已完成任务 ID。",
 					},
 					"request": map[string]any{
 						"type":        "string",
@@ -95,6 +96,7 @@ func Register(registry *plugin.Registry, manager TaskLookup, resumes *ResumeRegi
 			args.PluginName = strings.TrimSpace(args.PluginName)
 			args.TaskID = strings.TrimSpace(args.TaskID)
 			args.Request = strings.TrimSpace(args.Request)
+			log.Printf("continue_task request received: plugin=%s task_id=%s request=%q", args.PluginName, args.TaskID, args.Request)
 			if args.PluginName == "" || args.TaskID == "" || args.Request == "" {
 				return plugin.Result{Text: "你想在刚刚哪个任务基础上继续补充什么要求？"}, nil
 			}
@@ -110,6 +112,16 @@ func Register(registry *plugin.Registry, manager TaskLookup, resumes *ResumeRegi
 			if taskPlugin != args.PluginName {
 				return plugin.Result{Text: "这个任务和指定插件对不上，我先不继续处理。"}, nil
 			}
+			log.Printf(
+				"continue_task resolved task: task_id=%s plugin=%s title=%q parent_task_id=%s input=%q summary=%q result=%q",
+				task.ID,
+				taskPlugin,
+				strings.TrimSpace(task.Title),
+				strings.TrimSpace(task.ParentTaskID),
+				strings.TrimSpace(task.Input),
+				strings.TrimSpace(task.Summary),
+				strings.TrimSpace(task.Result),
+			)
 
 			title := strings.TrimSpace(task.Title)
 			if title == "" {

--- a/internal/tasks/manager.go
+++ b/internal/tasks/manager.go
@@ -23,6 +23,16 @@ type Manager struct {
 	onResultReportReady func()
 }
 
+type intentTaskChainSnapshot struct {
+	LatestTaskID    string
+	Plugin          string
+	RootTitle       string
+	RootInput       string
+	RecentFollowups []string
+	LatestSummary   string
+	LatestUpdatedAt time.Time
+}
+
 func NewManager(dsn string, artifactCacheDir string) (*Manager, error) {
 	store, err := NewStore(dsn)
 	if err != nil {
@@ -235,21 +245,22 @@ func (m *Manager) GetTask(taskID string) (*Task, bool) {
 	return nil, false
 }
 
+// CompletedTasksForIntent 生成“给 intent 模型看的最近已完成任务列表”。
+//
+// 这份列表不是给前端展示，也不是给 continue_task 执行阶段直接复用，
+// 而是专门给意图识别阶段做任务接续候选上下文：
+// 1. 先从内存态里拿到当前全部任务；
+// 2. 按 parent_task_id 把任务折叠成“任务链快照”，避免同一条链的旧节点重复进入 prompt；
+// 3. 每条快照只暴露这条链“最新的已完成节点”，并同时保留根任务输入和最近续做要求；
+// 4. 如果一条链最新节点不是 completed，则整条链暂时不进入 continue_task 候选；
+// 5. 最后按最新节点 UpdatedAt 从新到旧排序，并按 limit 截断。
 func (m *Manager) CompletedTasksForIntent(limit int) string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	tasks := append([]Task(nil), m.state.Tasks...)
-	sort.Slice(tasks, func(i, j int) bool {
-		return tasks[i].UpdatedAt.After(tasks[j].UpdatedAt)
-	})
-
 	var items []string
-	for _, task := range tasks {
-		if task.State != StateCompleted {
-			continue
-		}
-		items = append(items, formatCompletedTaskForIntent(task))
+	for _, snapshot := range buildIntentTaskChainSnapshots(m.state.Tasks, limit) {
+		items = append(items, formatIntentTaskChainSnapshot(snapshot))
 		if len(items) >= limit {
 			break
 		}
@@ -257,7 +268,7 @@ func (m *Manager) CompletedTasksForIntent(limit int) string {
 	if len(items) == 0 {
 		return ""
 	}
-	return "最近已完成任务列表如下。如果用户现在是在补充、修改、继续之前做完的任务，请优先从下面选择最匹配的任务并调用 continue_task：\n" + strings.Join(items, "\n")
+	return "下面是最近可继续的任务链快照。每条只代表一条任务链当前最新的已完成节点。\n如果用户现在是在补充、修改、继续之前已经做完的任务，请优先从下面选择最匹配的一条，并调用 continue_task。\n注意：调用 continue_task 时，task_id 必须填写 latest_task_id，plugin_name 必须填写 plugin，不要自己编造。\n\n" + strings.Join(items, "\n\n")
 }
 
 func formatProgressItem(task Task) string {
@@ -277,15 +288,217 @@ func formatProgressItem(task Task) string {
 	)
 }
 
-func formatCompletedTaskForIntent(task Task) string {
-	title := strings.TrimSpace(task.Title)
-	if title == "" {
-		title = "未命名任务"
+// formatIntentTaskChainSnapshot 把单条任务链快照压缩成给 intent 模型看的候选块。
+//
+// 它同时保留两层信息：
+// 1. 根任务语义锚点：root_title / root_input
+// 2. 当前最新完成状态：latest_task_id / recent_followups / latest_summary
+//
+// 这样模型既能按“原始想做什么”命中任务，也能按“最近改到哪一步”命中同一条链。
+func formatIntentTaskChainSnapshot(snapshot intentTaskChainSnapshot) string {
+	followups := "无"
+	if len(snapshot.RecentFollowups) > 0 {
+		followups = strings.Join(snapshot.RecentFollowups, "；")
 	}
+	return fmt.Sprintf(
+		"- latest_task_id=%s\n  plugin=%s\n  root_title=%s\n  root_input=%s\n  recent_followups=%s\n  latest_summary=%s",
+		snapshot.LatestTaskID,
+		snapshot.Plugin,
+		snapshot.RootTitle,
+		snapshot.RootInput,
+		followups,
+		snapshot.LatestSummary,
+	)
+}
+
+// buildIntentTaskChainSnapshots 把零散 task 行折叠成“给 continue_task 用的任务链快照”。
+//
+// 当前策略是：
+// 1. 先按 parent_task_id 找到根任务，把同一条链上的节点归并到一起；
+// 2. 每条链只保留一个对外候选，对应这条链当前最新的已完成节点；
+// 3. 如果这条链最新节点不是 completed，则整条链暂不进入 continue_task 候选；
+// 4. 快照里同时保留根任务输入和最近续做要求，兼顾原始目标和最近修改语义。
+func buildIntentTaskChainSnapshots(tasks []Task, limit int) []intentTaskChainSnapshot {
+	if limit <= 0 || len(tasks) == 0 {
+		return nil
+	}
+
+	byID := make(map[string]Task, len(tasks))
+	for _, task := range tasks {
+		if strings.TrimSpace(task.ID) == "" {
+			continue
+		}
+		byID[task.ID] = task
+	}
+
+	chains := make(map[string][]Task)
+	for _, task := range tasks {
+		if strings.TrimSpace(task.ID) == "" {
+			continue
+		}
+		rootID := resolveIntentTaskChainRootID(task, byID)
+		chains[rootID] = append(chains[rootID], task)
+	}
+
+	snapshots := make([]intentTaskChainSnapshot, 0, len(chains))
+	for rootID, chainTasks := range chains {
+		latest := latestTaskByUpdatedAt(chainTasks)
+		if strings.TrimSpace(latest.ID) == "" || latest.State != StateCompleted {
+			continue
+		}
+
+		root := rootTaskForIntent(rootID, chainTasks, byID)
+		snapshots = append(snapshots, intentTaskChainSnapshot{
+			LatestTaskID:    latest.ID,
+			Plugin:          taskPluginForIntent(latest),
+			RootTitle:       taskTitleForIntent(root),
+			RootInput:       taskInputForIntent(root),
+			RecentFollowups: recentFollowupsForIntent(chainTasks, root.ID),
+			LatestSummary:   taskSummaryForIntent(latest),
+			LatestUpdatedAt: latest.UpdatedAt,
+		})
+	}
+
+	sort.Slice(snapshots, func(i, j int) bool {
+		return snapshots[i].LatestUpdatedAt.After(snapshots[j].LatestUpdatedAt)
+	})
+	if len(snapshots) > limit {
+		snapshots = snapshots[:limit]
+	}
+	return snapshots
+}
+
+func resolveIntentTaskChainRootID(task Task, byID map[string]Task) string {
+	current := task
+	visited := make(map[string]struct{})
+	for {
+		currentID := strings.TrimSpace(current.ID)
+		if currentID == "" {
+			return strings.TrimSpace(task.ID)
+		}
+		if _, ok := visited[currentID]; ok {
+			return currentID
+		}
+		visited[currentID] = struct{}{}
+
+		parentID := strings.TrimSpace(current.ParentTaskID)
+		if parentID == "" {
+			return currentID
+		}
+
+		parent, ok := byID[parentID]
+		if !ok {
+			return currentID
+		}
+		current = parent
+	}
+}
+
+func rootTaskForIntent(rootID string, chainTasks []Task, byID map[string]Task) Task {
+	if root, ok := byID[strings.TrimSpace(rootID)]; ok {
+		return root
+	}
+	if len(chainTasks) == 0 {
+		return Task{}
+	}
+
+	root := chainTasks[0]
+	for _, task := range chainTasks[1:] {
+		if task.CreatedAt.Before(root.CreatedAt) {
+			root = task
+			continue
+		}
+		if task.CreatedAt.Equal(root.CreatedAt) && task.UpdatedAt.Before(root.UpdatedAt) {
+			root = task
+		}
+	}
+	return root
+}
+
+func latestTaskByUpdatedAt(tasks []Task) Task {
+	if len(tasks) == 0 {
+		return Task{}
+	}
+	latest := tasks[0]
+	for _, task := range tasks[1:] {
+		if task.UpdatedAt.After(latest.UpdatedAt) {
+			latest = task
+			continue
+		}
+		if task.UpdatedAt.Equal(latest.UpdatedAt) && task.CreatedAt.After(latest.CreatedAt) {
+			latest = task
+		}
+	}
+	return latest
+}
+
+func recentFollowupsForIntent(chainTasks []Task, rootTaskID string) []string {
+	type followup struct {
+		input     string
+		updatedAt time.Time
+	}
+
+	var items []followup
+	rootTaskID = strings.TrimSpace(rootTaskID)
+	for _, task := range chainTasks {
+		if strings.TrimSpace(task.ID) == "" || strings.TrimSpace(task.ID) == rootTaskID {
+			continue
+		}
+		input := compactTaskText(task.Input)
+		if input == "" {
+			continue
+		}
+		items = append(items, followup{
+			input:     input,
+			updatedAt: task.UpdatedAt,
+		})
+	}
+
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].updatedAt.Before(items[j].updatedAt)
+	})
+	if len(items) > 3 {
+		items = items[len(items)-3:]
+	}
+
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		result = append(result, item.input)
+	}
+	return result
+}
+
+func taskPluginForIntent(task Task) string {
 	pluginName := strings.TrimSpace(task.Plugin)
 	if pluginName == "" {
 		pluginName = strings.TrimSpace(task.Kind)
 	}
+	if pluginName == "" {
+		pluginName = "unknown_plugin"
+	}
+	return pluginName
+}
+
+func taskTitleForIntent(task Task) string {
+	title := strings.TrimSpace(task.Title)
+	if title == "" {
+		title = strings.TrimSpace(task.Kind)
+	}
+	if title == "" {
+		title = "未命名任务"
+	}
+	return compactTaskText(title)
+}
+
+func taskInputForIntent(task Task) string {
+	input := compactTaskText(task.Input)
+	if input == "" {
+		return "无"
+	}
+	return input
+}
+
+func taskSummaryForIntent(task Task) string {
 	summary := compactTaskText(task.Summary)
 	if summary == "" {
 		summary = compactTaskText(task.Result)
@@ -293,14 +506,7 @@ func formatCompletedTaskForIntent(task Task) string {
 	if summary == "" {
 		summary = "暂无摘要"
 	}
-
-	return fmt.Sprintf(
-		"- task_id=%s plugin=%s title=%s summary=%s",
-		task.ID,
-		pluginName,
-		title,
-		summary,
-	)
+	return summary
 }
 
 func (m *Manager) BuildResultReport(limit int) (string, []string) {

--- a/internal/tasks/manager_test.go
+++ b/internal/tasks/manager_test.go
@@ -118,7 +118,7 @@ func TestManagerCancelLatest(t *testing.T) {
 	}
 }
 
-func TestCompletedTasksForIntentIncludesPluginSummary(t *testing.T) {
+func TestCompletedTasksForIntentUsesRootTaskSnapshot(t *testing.T) {
 	t.Helper()
 
 	manager, err := NewManager(testmysql.NewDSN(t), t.TempDir())
@@ -133,6 +133,7 @@ func TestCompletedTasksForIntentIncludesPluginSummary(t *testing.T) {
 			Plugin:    "complex_task",
 			Kind:      "complex_task",
 			Title:     "做网页",
+			Input:     "帮我做一个关于天气的小游戏",
 			State:     StateCompleted,
 			Summary:   "已经做好一个可交付网页，文件放在桌面。",
 			CreatedAt: now,
@@ -141,8 +142,146 @@ func TestCompletedTasksForIntentIncludesPluginSummary(t *testing.T) {
 	}
 
 	text := manager.CompletedTasksForIntent(3)
-	if !strings.Contains(text, "task_id=task_1 plugin=complex_task title=做网页 summary=已经做好一个可交付网页，文件放在桌面。") {
+	if !strings.Contains(text, "latest_task_id=task_1") {
 		t.Fatalf("text = %q", text)
+	}
+	if !strings.Contains(text, "plugin=complex_task") {
+		t.Fatalf("text = %q", text)
+	}
+	if !strings.Contains(text, "root_title=做网页") {
+		t.Fatalf("text = %q", text)
+	}
+	if !strings.Contains(text, "root_input=帮我做一个关于天气的小游戏") {
+		t.Fatalf("text = %q", text)
+	}
+	if !strings.Contains(text, "recent_followups=无") {
+		t.Fatalf("text = %q", text)
+	}
+	if !strings.Contains(text, "latest_summary=已经做好一个可交付网页，文件放在桌面。") {
+		t.Fatalf("text = %q", text)
+	}
+}
+
+func TestCompletedTasksForIntentCollapsesContinuationChain(t *testing.T) {
+	t.Helper()
+
+	manager, err := NewManager(testmysql.NewDSN(t), t.TempDir())
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	now := time.Now()
+	manager.state.Tasks = []Task{
+		{
+			ID:        "task_1",
+			Plugin:    "complex_task",
+			Kind:      "complex_task",
+			Title:     "天气小游戏",
+			Input:     "帮我做一个关于天气的小游戏",
+			State:     StateCompleted,
+			Summary:   "第一版小游戏已经完成。",
+			CreatedAt: now,
+			UpdatedAt: now,
+		},
+		{
+			ID:           "task_2",
+			Plugin:       "complex_task",
+			Kind:         "complex_task",
+			Title:        "接续：天气小游戏",
+			Input:        "加一点动画",
+			ParentTaskID: "task_1",
+			State:        StateCompleted,
+			Summary:      "已经补上基础动画。",
+			CreatedAt:    now.Add(1 * time.Minute),
+			UpdatedAt:    now.Add(1 * time.Minute),
+		},
+		{
+			ID:           "task_3",
+			Plugin:       "complex_task",
+			Kind:         "complex_task",
+			Title:        "接续：接续：天气小游戏",
+			Input:        "再炫酷一点",
+			ParentTaskID: "task_2",
+			State:        StateCompleted,
+			Summary:      "当前版本已经加入更强的动画效果和视觉强化。",
+			CreatedAt:    now.Add(2 * time.Minute),
+			UpdatedAt:    now.Add(2 * time.Minute),
+		},
+	}
+
+	text := manager.CompletedTasksForIntent(5)
+	if !strings.Contains(text, "latest_task_id=task_3") {
+		t.Fatalf("text = %q", text)
+	}
+	if strings.Contains(text, "latest_task_id=task_1") || strings.Contains(text, "latest_task_id=task_2") {
+		t.Fatalf("text = %q, want only latest task id", text)
+	}
+	if !strings.Contains(text, "root_title=天气小游戏") {
+		t.Fatalf("text = %q", text)
+	}
+	if !strings.Contains(text, "root_input=帮我做一个关于天气的小游戏") {
+		t.Fatalf("text = %q", text)
+	}
+	if !strings.Contains(text, "recent_followups=加一点动画；再炫酷一点") {
+		t.Fatalf("text = %q", text)
+	}
+	if !strings.Contains(text, "latest_summary=当前版本已经加入更强的动画效果和视觉强化。") {
+		t.Fatalf("text = %q", text)
+	}
+}
+
+func TestCompletedTasksForIntentSkipsChainWhenLatestNodeIsNotCompleted(t *testing.T) {
+	t.Helper()
+
+	manager, err := NewManager(testmysql.NewDSN(t), t.TempDir())
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	now := time.Now()
+	manager.state.Tasks = []Task{
+		{
+			ID:        "task_1",
+			Plugin:    "complex_task",
+			Kind:      "complex_task",
+			Title:     "天气小游戏",
+			Input:     "帮我做一个关于天气的小游戏",
+			State:     StateCompleted,
+			Summary:   "第一版小游戏已经完成。",
+			CreatedAt: now,
+			UpdatedAt: now,
+		},
+		{
+			ID:           "task_2",
+			Plugin:       "complex_task",
+			Kind:         "complex_task",
+			Title:        "接续：天气小游戏",
+			Input:        "再加一点音效",
+			ParentTaskID: "task_1",
+			State:        StateRunning,
+			Summary:      "Claude 正在补音效。",
+			CreatedAt:    now.Add(1 * time.Minute),
+			UpdatedAt:    now.Add(1 * time.Minute),
+		},
+		{
+			ID:        "task_10",
+			Plugin:    "complex_task",
+			Kind:      "complex_task",
+			Title:     "故事文件",
+			Input:     "帮我写一个小故事文件",
+			State:     StateCompleted,
+			Summary:   "故事文件已经准备好。",
+			CreatedAt: now.Add(2 * time.Minute),
+			UpdatedAt: now.Add(2 * time.Minute),
+		},
+	}
+
+	text := manager.CompletedTasksForIntent(5)
+	if strings.Contains(text, "天气小游戏") || strings.Contains(text, "task_2") {
+		t.Fatalf("text = %q, want running chain excluded", text)
+	}
+	if !strings.Contains(text, "latest_task_id=task_10") {
+		t.Fatalf("text = %q, want completed chain still included", text)
 	}
 }
 


### PR DESCRIPTION
## 变更说明
- 将 `CompletedTasksForIntent` 从“按单条 task 平铺”改为“按任务链快照构建候选”，同一条链只向 intent 暴露一个候选块
- `continue_task` 候选现在会同时带上：`latest_task_id`、`plugin`、`root_title`、`root_input`、`recent_followups`、`latest_summary`
- 如果一条链最新节点不是 `completed`，当前不会进入 `continue_task` 候选，避免把仍在执行中的链误当成可续做任务
- 调整任务意图识别 prompt，明确要求模型结合 `root_input / recent_followups / latest_summary` 判断，并在命中 `continue_task` 时必须使用 `latest_task_id`
- 为 `continue_task` 工具补充调用日志，能看到实际选择了哪个任务、任务标题、父任务、输入、摘要和结果
- 新增工具意图识别文档，说明整体分流机制以及 `continue_task` 为什么按任务链快照拼接，并附带根任务 / 多次续做两个 case

## 文档
- 新增 `docs/tool-intent-routing.md`
- 更新 `docs/feature-overview.md`

## 测试
- `GOCACHE=$(pwd)/.gocache go test ./internal/tasks ./internal/llm ./internal/plugins/continuetask`
- 覆盖了：
  - 只有根任务时的任务链快照拼接
  - 多次续做时只保留最新已完成节点
  - 最新节点非 `completed` 时不进入候选
  - intent 请求体里确实带上任务链快照 prompt

Fixed #37
