### PR TITLE
docs: add CI and codecov badges to README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,15 @@ jobs:
         env:
           GOCACHE: ${{ github.workspace }}/.gocache
           OPEN_XIAOAI_AGENT_TEST_MYSQL_DSN: root:root@tcp(127.0.0.1:3306)/open_xiaoai_agent_test
-        run: go test ./...
+        run: go test -coverprofile=coverage.out -coverpkg=./... ./...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.out
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   web-build:
     name: Web Build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # XiaoAiAgent
 
+[![CI](https://github.com/luoliwoshang/open-xiaoai-agent/actions/workflows/ci.yml/badge.svg)](https://github.com/luoliwoshang/open-xiaoai-agent/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/luoliwoshang/open-xiaoai-agent/branch/main/graph/badge.svg)](https://codecov.io/gh/luoliwoshang/open-xiaoai-agent)
+
 `XiaoAiAgent` 是面向 [`open-xiaoai`](https://github.com/idootop/open-xiaoai) 生态的独立服务端，仓库名为 `open-xiaoai-agent`。
 
 它想做的事情很简单：把“小爱同学”从一个语音入口，增强成一个真正能对话、能接任务、能追进度、能回来继续做事的 AI 助理。


### PR DESCRIPTION
## Summary

- Add CI status badge to README
- Add Codecov test coverage badge to README
- Add Go test coverage generation and Codecov upload to CI workflow

## Test plan

- [x] Verify badges render correctly in README
- [x] Verify badge links point to correct CI workflow and Codecov page
- [x] Verify CI workflow generates coverage.out and uploads to Codecov

🤖 Generated with [Claude Code](https://claude.com/claude-code)