### PR TITLE
feat: add task chain tracing in dashboard

### DIFF
--- a/frontend/src/components/dashboard/TaskChainBar.tsx
+++ b/frontend/src/components/dashboard/TaskChainBar.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react'
+import { fetchTaskChain } from '../../lib/api'
+import { StatusBadge } from '../ui/StatusBadge'
+import type { Task } from '../../types'
+
+interface TaskChainBarProps {
+  taskId: string
+  onSelect?: (taskId: string) => void
+}
+
+export function TaskChainBar({ taskId, onSelect }: TaskChainBarProps) {
+  const [chain, setChain] = useState<Task[]>([])
+
+  useEffect(() => {
+    let cancelled = false
+    fetchTaskChain(taskId)
+      .then((tasks) => {
+        if (!cancelled) setChain(tasks)
+      })
+      .catch(() => {
+        if (!cancelled) setChain([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [taskId])
+
+  if (chain.length <= 1) return null
+
+  return (
+    <div className="task-chain-bar">
+      <span className="task-chain-label">任务链</span>
+      <div className="task-chain-nodes">
+        {chain.map((t, i) => {
+          const isCurrent = t.id === taskId
+          const isLast = i === chain.length - 1
+          return (
+            <span key={t.id} className="task-chain-node">
+              <button
+                className={`task-chain-item ${isCurrent ? 'current' : ''}`}
+                onClick={() => !isCurrent && onSelect?.(t.id)}
+                disabled={isCurrent}
+              >
+                <span className="task-chain-id">{t.id.slice(0, 8)}</span>
+                <StatusBadge state={t.state} />
+              </button>
+              {!isLast && <span className="task-chain-sep">&rsaquo;</span>}
+            </span>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/dashboard/TaskDetailModal.tsx
+++ b/frontend/src/components/dashboard/TaskDetailModal.tsx
@@ -10,6 +10,7 @@ interface TaskDetailModalProps {
   artifacts: TaskArtifact[]
   claudeRecords: ClaudeRecord[]
   onClose: () => void
+  onSelectTask?: (taskId: string) => void
 }
 
 export function TaskDetailModal({
@@ -18,6 +19,7 @@ export function TaskDetailModal({
   artifacts,
   claudeRecords,
   onClose,
+  onSelectTask,
 }: TaskDetailModalProps) {
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
@@ -44,7 +46,7 @@ export function TaskDetailModal({
         </div>
 
         <div className="task-modal-layout">
-          <TaskDetailPane task={task} />
+          <TaskDetailPane task={task} onSelectTask={onSelectTask} />
           <TaskSideCards
             task={task}
             events={events}

--- a/frontend/src/components/dashboard/TaskDetailPane.tsx
+++ b/frontend/src/components/dashboard/TaskDetailPane.tsx
@@ -2,9 +2,11 @@ import { Cpu } from 'lucide-react'
 import type { Task } from '../../types'
 import { formatTime, stateLabels } from '../../lib/dashboard'
 import { StatusBadge } from '../ui/StatusBadge'
+import { TaskChainBar } from './TaskChainBar'
 
 interface TaskDetailPaneProps {
   task: Task | null
+  onSelectTask?: (taskId: string) => void
 }
 
 function getProgressPercent(task: Task): number {
@@ -19,7 +21,7 @@ function getProgressPercent(task: Task): number {
 
 const PROGRESS_STEPS = ['接收', '调度', '执行', '完成', '交付']
 
-export function TaskDetailPane({ task }: TaskDetailPaneProps) {
+export function TaskDetailPane({ task, onSelectTask }: TaskDetailPaneProps) {
   if (!task) {
     return (
       <div className="section-card task-detail-card">
@@ -46,6 +48,7 @@ export function TaskDetailPane({ task }: TaskDetailPaneProps) {
           </span>
         </div>
         <div className="task-detail-title">{task.title || task.kind}</div>
+        <TaskChainBar taskId={task.id} onSelect={onSelectTask} />
         <div className="task-detail-meta">
           <div className="meta-item">
             <span className="meta-label">ID</span>
@@ -63,12 +66,6 @@ export function TaskDetailPane({ task }: TaskDetailPaneProps) {
             <span className="meta-label">更新时间</span>
             <span className="meta-value">{formatTime(task.updated_at)}</span>
           </div>
-          {task.parent_task_id && (
-            <div className="meta-item">
-              <span className="meta-label">父任务</span>
-              <span className="meta-value">{task.parent_task_id.slice(0, 8)}...</span>
-            </div>
-          )}
         </div>
       </div>
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4,6 +4,7 @@ import type {
   MemoryManagedFile,
   MemoryUpdateLogPage,
   SessionSettings,
+  Task,
   WeChatLoginStart,
   WeChatLoginStatus,
 } from '../types'
@@ -24,6 +25,11 @@ async function json<T>(path: string, init?: RequestInit): Promise<T> {
 
 export function fetchState(): Promise<DashboardState> {
   return json('/state')
+}
+
+export async function fetchTaskChain(taskId: string): Promise<Task[]> {
+  const payload = await json<{ chain: Task[] }>(`/tasks/${encodeURIComponent(taskId)}/chain`)
+  return payload.chain ?? []
 }
 
 export function submitAssistantASR(text: string): Promise<{ ok: boolean; text: string }> {

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -145,6 +145,7 @@ export function DashboardPage({ state, onReload }: DashboardPageProps) {
           artifacts={state.artifacts}
           claudeRecords={state.claude_records}
           onClose={() => setSelectedTaskId(null)}
+          onSelectTask={setSelectedTaskId}
         />
       )}
     </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -638,6 +638,80 @@ body {
   font-family: var(--font-mono);
 }
 
+/* Task chain breadcrumb */
+.task-chain-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 8px 0;
+  padding: 8px 10px;
+  background: var(--bg-elevated);
+  border-radius: 8px;
+  overflow-x: auto;
+}
+
+.task-chain-label {
+  font-size: 10px;
+  color: var(--text-ghost);
+  font-family: var(--font-mono);
+  font-weight: 500;
+  flex-shrink: 0;
+}
+
+.task-chain-nodes {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: nowrap;
+}
+
+.task-chain-node {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.task-chain-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-card);
+  cursor: pointer;
+  font-size: 11px;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.task-chain-item:not(:disabled):hover {
+  background: var(--bg-hover);
+  border-color: var(--accent);
+}
+
+.task-chain-item.current {
+  background: var(--accent-bg);
+  border-color: var(--accent);
+  cursor: default;
+  font-weight: 600;
+}
+
+.task-chain-id {
+  font-family: var(--font-mono);
+  color: var(--text-secondary);
+}
+
+.task-chain-item.current .task-chain-id {
+  color: var(--accent);
+}
+
+.task-chain-sep {
+  color: var(--text-ghost);
+  font-size: 14px;
+  flex-shrink: 0;
+}
+
 /* Progress bar */
 .progress-section {
   padding: 14px;

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -235,6 +235,14 @@ func (s *Server) handleTaskArtifactDownload(w http.ResponseWriter, r *http.Reque
 
 	path := strings.TrimPrefix(r.URL.Path, "/api/tasks/")
 	parts := strings.Split(path, "/")
+
+	// GET /api/tasks/{taskID}/chain
+	if len(parts) == 2 && parts[1] == "chain" {
+		s.handleTaskChain(w, r, strings.TrimSpace(parts[0]))
+		return
+	}
+
+	// GET /api/tasks/{taskID}/artifacts/{artifactID}/download
 	if len(parts) != 4 || parts[1] != "artifacts" || parts[3] != "download" {
 		http.NotFound(w, r)
 		return
@@ -272,6 +280,15 @@ func (s *Server) handleTaskArtifactDownload(w http.ResponseWriter, r *http.Reque
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("Content-Disposition", buildAttachmentDisposition(artifact.FileName))
 	http.ServeContent(w, r, artifact.FileName, artifact.CreatedAt, file)
+}
+
+func (s *Server) handleTaskChain(w http.ResponseWriter, _ *http.Request, taskID string) {
+	if s.tasks == nil {
+		http.Error(w, "task manager is not configured", http.StatusServiceUnavailable)
+		return
+	}
+	chain := s.tasks.TaskChain(taskID)
+	writeJSON(w, map[string]any{"chain": chain})
 }
 
 func buildAttachmentDisposition(fileName string) string {

--- a/internal/tasks/manager.go
+++ b/internal/tasks/manager.go
@@ -642,6 +642,65 @@ func (m *Manager) ArtifactsSnapshot() []Artifact {
 	return artifacts
 }
 
+func (m *Manager) TaskChain(taskID string) []Task {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	taskID = strings.TrimSpace(taskID)
+	if taskID == "" {
+		return nil
+	}
+
+	byID := make(map[string]Task, len(m.state.Tasks))
+	for _, t := range m.state.Tasks {
+		byID[t.ID] = t
+	}
+
+	task, ok := byID[taskID]
+	if !ok {
+		return nil
+	}
+
+	// ancestors: walk up from current task to root
+	lineage := buildIntentTaskLineage(task, byID)
+
+	// collect all IDs in the chain so far
+	inChain := make(map[string]struct{}, len(lineage))
+	for _, t := range lineage {
+		inChain[t.ID] = struct{}{}
+	}
+
+	// descendants: find all tasks whose parent is in the chain (BFS)
+	chainSet := inChain
+	var descendants []Task
+	queue := make([]string, 0, len(lineage))
+	for _, t := range lineage {
+		queue = append(queue, t.ID)
+	}
+	for len(queue) > 0 {
+		parentID := queue[0]
+		queue = queue[1:]
+		for _, t := range m.state.Tasks {
+			if t.ParentTaskID != parentID {
+				continue
+			}
+			if _, exists := chainSet[t.ID]; exists {
+				continue
+			}
+			chainSet[t.ID] = struct{}{}
+			descendants = append(descendants, t)
+			queue = append(queue, t.ID)
+		}
+	}
+
+	// merge: ancestors + descendants, sorted by CreatedAt
+	all := append(lineage, descendants...)
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].CreatedAt.Before(all[j].CreatedAt)
+	})
+	return all
+}
+
 func (m *Manager) GetArtifact(taskID string, artifactID string) (*Artifact, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/tasks/manager_test.go
+++ b/internal/tasks/manager_test.go
@@ -493,3 +493,66 @@ func waitForTaskState(t *testing.T, manager *Manager, taskID string, want State)
 	t.Fatalf("task %q did not reach state %q before timeout", taskID, want)
 	return Task{}
 }
+
+func TestTaskChain(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	manager := &Manager{
+		state: fileState{
+			Tasks: []Task{
+				{ID: "task_1", Title: "root", State: StateCompleted, CreatedAt: now, UpdatedAt: now},
+				{ID: "task_2", Title: "cont1", ParentTaskID: "task_1", State: StateCompleted, CreatedAt: now.Add(1 * time.Minute), UpdatedAt: now.Add(1 * time.Minute)},
+				{ID: "task_3", Title: "cont2", ParentTaskID: "task_2", State: StateRunning, CreatedAt: now.Add(2 * time.Minute), UpdatedAt: now.Add(2 * time.Minute)},
+				{ID: "task_4", Title: "other", State: StateCompleted, CreatedAt: now.Add(3 * time.Minute), UpdatedAt: now.Add(3 * time.Minute)},
+			},
+		},
+	}
+
+	// middle of chain: should return full chain in CreatedAt order
+	chain := manager.TaskChain("task_2")
+	if len(chain) != 3 {
+		t.Fatalf("TaskChain(task_2) len = %d, want 3", len(chain))
+	}
+	if chain[0].ID != "task_1" || chain[1].ID != "task_2" || chain[2].ID != "task_3" {
+		t.Fatalf("TaskChain(task_2) = %v, want [task_1 task_2 task_3]", taskIDs(chain))
+	}
+
+	// root of chain
+	chain = manager.TaskChain("task_1")
+	if len(chain) != 3 {
+		t.Fatalf("TaskChain(task_1) len = %d, want 3", len(chain))
+	}
+
+	// leaf of chain
+	chain = manager.TaskChain("task_3")
+	if len(chain) != 3 {
+		t.Fatalf("TaskChain(task_3) len = %d, want 3", len(chain))
+	}
+
+	// standalone task (no chain)
+	chain = manager.TaskChain("task_4")
+	if len(chain) != 1 {
+		t.Fatalf("TaskChain(task_4) len = %d, want 1", len(chain))
+	}
+
+	// non-existent task
+	chain = manager.TaskChain("nope")
+	if len(chain) != 0 {
+		t.Fatalf("TaskChain(nope) len = %d, want 0", len(chain))
+	}
+
+	// empty ID
+	chain = manager.TaskChain("")
+	if len(chain) != 0 {
+		t.Fatalf("TaskChain(empty) len = %d, want 0", len(chain))
+	}
+}
+
+func taskIDs(chain []Task) []string {
+	ids := make([]string, len(chain))
+	for i, t := range chain {
+		ids[i] = t.ID
+	}
+	return ids
+}


### PR DESCRIPTION
## Summary
- Backend: new `GET /api/tasks/{taskID}/chain` endpoint returning full task chain (ancestors + descendants)
- Frontend: breadcrumb-style `TaskChainBar` component showing chain nodes with clickable navigation
- Replaces static `parent_task_id` display with interactive chain view

## Test plan
- [x] `TestTaskChain` passes (middle-of-chain, root, leaf, standalone, non-existent, empty ID)
- [x] Frontend builds clean (`npm run build:fe`)
- [x] Full Go test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)