### PR TITLE
fix: show task title instead of ID in chain breadcrumb

### DIFF
--- a/frontend/src/components/dashboard/TaskChainBar.tsx
+++ b/frontend/src/components/dashboard/TaskChainBar.tsx
@@ -34,14 +34,17 @@ export function TaskChainBar({ taskId, onSelect }: TaskChainBarProps) {
         {chain.map((t, i) => {
           const isCurrent = t.id === taskId
           const isLast = i === chain.length - 1
+          const label = t.title || t.kind
+          const tip = `${t.id.slice(0, 8)} · ${label}`
           return (
             <span key={t.id} className="task-chain-node">
               <button
                 className={`task-chain-item ${isCurrent ? 'current' : ''}`}
                 onClick={() => !isCurrent && onSelect?.(t.id)}
                 disabled={isCurrent}
+                title={tip}
               >
-                <span className="task-chain-id">{t.id.slice(0, 8)}</span>
+                <span className="task-chain-title">{label}</span>
                 <StatusBadge state={t.state} />
               </button>
               {!isLast && <span className="task-chain-sep">&rsaquo;</span>}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -697,12 +697,15 @@ body {
   font-weight: 600;
 }
 
-.task-chain-id {
-  font-family: var(--font-mono);
+.task-chain-title {
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: var(--text-secondary);
 }
 
-.task-chain-item.current .task-chain-id {
+.task-chain-item.current .task-chain-title {
   color: var(--accent);
 }
 


### PR DESCRIPTION
## Summary
- 任务链面包屑节点改为显示任务标题，不再显示 task_id
- 超长标题自动省略，hover tooltip 显示 `短id · 标题` 方便识别

🤖 Generated with [Claude Code](https://claude.com/claude-code)