### PR TITLE
fix: show full task ID in detail pane

### DIFF
--- a/frontend/src/components/dashboard/TaskDetailPane.tsx
+++ b/frontend/src/components/dashboard/TaskDetailPane.tsx
@@ -52,7 +52,7 @@ export function TaskDetailPane({ task, onSelectTask }: TaskDetailPaneProps) {
         <div className="task-detail-meta">
           <div className="meta-item">
             <span className="meta-label">ID</span>
-            <span className="meta-value">{task.id.slice(0, 8)}...</span>
+            <span className="meta-value">{task.id}</span>
           </div>
           <div className="meta-item">
             <span className="meta-label">类型</span>


### PR DESCRIPTION
## Summary
- 任务详情中的 ID 不再截断，显示完整 ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)