### PR TITLE
ci: only trigger push CI on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- `push` 事件只在 `main` 分支触发，PR 分支仅通过 `pull_request` 事件触发 CI，避免重复运行

🤖 Generated with [Claude Code](https://claude.com/claude-code)